### PR TITLE
Add PD17D4 darwinbuild plist

### DIFF
--- a/plists/PD17D4.plist
+++ b/plists/PD17D4.plist
@@ -44,7 +44,7 @@
 			<key>version</key>
 			<string>10</string>
 			<key>github</key>
-			<string>Andromeda-OS/libSystem</string>
+			<string>PureDarwin/libSystem</string>
 		</dict>
 
 		<key>corecrypto</key>
@@ -67,7 +67,7 @@
 			<key>version</key>
 			<string>161.1</string>
 			<key>github</key>
-			<string>Andromeda-OS/libplatform</string>
+			<string>PureDarwin/libplatform</string>
 			<key>dependencies</key>
 			<dict>
 				<key>header</key>
@@ -82,7 +82,7 @@
 			<key>version</key>
 			<string>10</string>
 			<key>github</key>
-			<string>Andromeda-OS/libpthread</string>
+			<string>PureDarwin/libpthread</string>
 			<key>dependencies</key>
 			<dict>
 				<key>header</key>
@@ -109,7 +109,12 @@
 			<key>version</key>
 			<string>10</string>
 			<key>github</key>
-			<string>Andromeda-OS/libxpc</string>
+			<dict>
+				<key>repo</key>
+				<string>PureDarwin/launchd-and-libxpc</string>
+				<key>tag</key>
+				<string>10</string>
+			</dict>
 		</dict>
 
 		<key>xnubuild</key>

--- a/plists/PD17D4.plist
+++ b/plists/PD17D4.plist
@@ -40,6 +40,14 @@
 
 	<key>projects</key>
 	<dict>
+		<key>Libsystem</key>
+		<dict>
+			<key>version</key>
+			<string>10</string>
+			<key>github</key>
+			<string>Andromeda-OS/libSystem</string>
+		</dict>
+
 		<key>corecrypto</key>
 		<dict>
 			<key>version</key>
@@ -53,14 +61,6 @@
 					<string>xnubuild</string>
 				</array>
 			</dict>
-		</dict>
-
-		<key>Libsystem</key>
-		<dict>
-			<key>version</key>
-			<string>10</string>
-			<key>github</key>
-			<string>Andromeda-OS/libSystem</string>
 		</dict>
 
 		<key>libplatform</key>

--- a/plists/PD17D4.plist
+++ b/plists/PD17D4.plist
@@ -55,6 +55,46 @@
 			</dict>
 		</dict>
 
+		<key>Libsystem</key>
+		<dict>
+			<key>version</key>
+			<string>10</string>
+			<key>github</key>
+			<string>Andromeda-OS/libSystem</string>
+		</dict>
+
+		<key>libplatform</key>
+		<dict>
+			<key>version</key>
+			<string>161.1</string>
+			<key>github</key>
+			<string>Andromeda-OS/libplatform</string>
+			<key>dependencies</key>
+			<dict>
+				<key>header</key>
+				<array>
+					<string>xnubuild</string>
+				</array>
+			</dict>
+		</dict>
+
+		<key>libpthread</key>
+		<dict>
+			<key>version</key>
+			<string>10</string>
+			<key>github</key>
+			<string>Andromeda-OS/libpthread</string>
+			<key>dependencies</key>
+			<dict>
+				<key>header</key>
+				<array>
+					<string>Libsystem</string>
+					<string>libplatform</string>
+					<string>xnubuild</string>
+				</array>
+			</dict>
+		</dict>
+
 		<key>libsyscall</key>
 		<dict>
 			<key>version</key>

--- a/plists/PD17D4.plist
+++ b/plists/PD17D4.plist
@@ -4,7 +4,6 @@
 <dict>
 	<key>source_sites</key>
 	<array>
-		<string>https://opensource.apple.com/tarballs</string>
 	</array>
 
 	<key>build</key>

--- a/plists/PD17D4.plist
+++ b/plists/PD17D4.plist
@@ -109,12 +109,7 @@
 			<key>version</key>
 			<string>10</string>
 			<key>github</key>
-			<dict>
-				<key>repo</key>
-				<string>PureDarwin/launchd-and-libxpc</string>
-				<key>tag</key>
-				<string>10</string>
-			</dict>
+			<string>PureDarwin/launchd-and-libxpc</string>
 		</dict>
 
 		<key>xnubuild</key>

--- a/plists/PD17D4.plist
+++ b/plists/PD17D4.plist
@@ -70,7 +70,7 @@
 			<key>version</key>
 			<string>10</string>
 			<key>github</key>
-			<string>Andromeda-OS/launchd-and-libxpc</string>
+			<string>Andromeda-OS/libxpc</string>
 		</dict>
 
 		<key>xnubuild</key>

--- a/plists/PD17D4.plist
+++ b/plists/PD17D4.plist
@@ -20,30 +20,10 @@
 		<string>YES</string>
 		<key>MACOSX_DEPLOYMENT_TARGET</key>
 		<string>10.13</string>
-		<key>NEXT_ROOT</key>
-		<string></string>
-		<key>RC_ARCHS</key>
-		<string>x86_64</string>
-		<key>RC_JASPER</key>
-		<string>YES</string>
-		<key>RC_NONARCH_CFLAGS</key>
-		<string>-pipe -no-cpp-precomp</string>
-		<key>RC_OS</key>
-		<string>macosx</string>
-		<key>RC_PRIVATE</key>
-		<string>/private</string>
-		<key>RC_RELEASE</key>
-		<string>Sierra</string>
-		<key>RC_XBS</key>
-		<string>YES</string>
-		<key>SEPARATE_STRIP</key>
-		<string>YES</string>
 		<key>UNAME_RELEASE</key>
-		<string>16.5</string>
+		<string>17.4</string>
 		<key>UNAME_SYSNAME</key>
 		<string>Darwin</string>
-		<key>SYSTEM_LIBRARY_DIR</key>
-		<string>/System/Library</string>
 		<key>RC_TARGET_CONFIG</key>
 		<string>MacOSX</string>
 		<key>SDKROOT</key>

--- a/plists/PD17D4.plist
+++ b/plists/PD17D4.plist
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>source_sites</key>
+	<array>
+		<string>https://opensource.apple.com/tarballs</string>
+	</array>
+
+	<key>build</key>
+	<string>PD17D4</string>
+	<key>darwin</key>
+	<string>Darwin 17.4</string>
+	<key>macosx</key>
+	<string>macOS 10.12.4</string>
+
+	<key>environment</key>
+	<dict>
+		<key>INSTALLED_PRODUCT_ASIDES</key>
+		<string>YES</string>
+		<key>MACOSX_DEPLOYMENT_TARGET</key>
+		<string>10.13</string>
+		<key>NEXT_ROOT</key>
+		<string></string>
+		<key>RC_ARCHS</key>
+		<string>x86_64</string>
+		<key>RC_JASPER</key>
+		<string>YES</string>
+		<key>RC_NONARCH_CFLAGS</key>
+		<string>-pipe -no-cpp-precomp</string>
+		<key>RC_OS</key>
+		<string>macosx</string>
+		<key>RC_PRIVATE</key>
+		<string>/private</string>
+		<key>RC_RELEASE</key>
+		<string>Sierra</string>
+		<key>RC_XBS</key>
+		<string>YES</string>
+		<key>SEPARATE_STRIP</key>
+		<string>YES</string>
+		<key>UNAME_RELEASE</key>
+		<string>16.5</string>
+		<key>UNAME_SYSNAME</key>
+		<string>Darwin</string>
+		<key>SYSTEM_LIBRARY_DIR</key>
+		<string>/System/Library</string>
+		<key>RC_TARGET_CONFIG</key>
+		<string>MacOSX</string>
+		<key>SDKROOT</key>
+		<string>macosx10.13</string>
+	</dict>
+
+	<key>groups</key>
+	<dict>
+		<key>boot</key>
+		<array>
+			<string>xnu AppleI386GenericPlatform corecrypto booter</string>
+		</array>
+	</dict>
+
+	<key>projects</key>
+	<dict>
+		<key>corecrypto</key>
+		<dict>
+			<key>version</key>
+			<string>2000</string>
+			<key>github</key>
+			<string>Andromeda-OS/corecrypto</string>
+			<key>dependencies</key>
+			<dict>
+				<key>header</key>
+				<array>
+					<string>xnubuild</string>
+				</array>
+			</dict>
+		</dict>
+
+		<key>libsyscall</key>
+		<dict>
+			<key>version</key>
+			<string>10.13</string>
+			<key>original</key>
+			<string>xnubuild</string>
+			<key>github</key>
+			<string>Andromeda-OS/xnubuild</string>
+		</dict>
+
+		<key>xnubuild</key>
+		<dict>
+			<key>version</key>
+			<string>10.13</string>
+			<key>github</key>
+			<string>Andromeda-OS/xnubuild</string>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/plists/PD17D4.plist
+++ b/plists/PD17D4.plist
@@ -85,6 +85,14 @@
 			<string>Andromeda-OS/xnubuild</string>
 		</dict>
 
+		<key>libxpc</key>
+		<dict>
+			<key>version</key>
+			<string>10</string>
+			<key>github</key>
+			<string>Andromeda-OS/launchd-and-libxpc</string>
+		</dict>
+
 		<key>xnubuild</key>
 		<dict>
 			<key>version</key>


### PR DESCRIPTION
Does mostly what the title says. Note that this plist is being assembled from scratch, rather than modified from an Apple-supplied darwinbuild plist as in the past. All projects currently have been verified that they build, and all required git tags (except for libxpc-10, see below) have been pushed. 