### PR TITLE
Add PD18.0 darwinbuild plist

### DIFF
--- a/patches/dtrace-284.200.15.host-tools.p1.patch
+++ b/patches/dtrace-284.200.15.host-tools.p1.patch
@@ -1,0 +1,111 @@
+diff --git a/config/ctftools.xcconfig b/config/ctftools.xcconfig
+index 88fc9e0..dea38cb 100644
+--- a/config/ctftools.xcconfig
++++ b/config/ctftools.xcconfig
+@@ -1,3 +1,6 @@
+ // On OSX, binaries are not built fat.
+ VALID_ARCHS[sdk=macosx*] = $(ARCHS_STANDARD_64_BIT)
+ ARCHS[sdk=macosx*] = $(ARCHS_STANDARD_64_BIT)
++
++HEADER_SEARCH_PATHS = head lib/libelf lib/libdwarf compat/opensolaris/sys
++USE_HEADERMAPS = NO
+diff --git a/dtrace.xcodeproj/project.pbxproj b/dtrace.xcodeproj/project.pbxproj
+index b123feb..46f7fcf 100644
+--- a/dtrace.xcodeproj/project.pbxproj
++++ b/dtrace.xcodeproj/project.pbxproj
+@@ -13767,6 +13767,7 @@
+ 		};
+ 		6EBC9778099BFB530001019C /* Debug */ = {
+ 			isa = XCBuildConfiguration;
++			baseConfigurationReference = 45A48B3618194C410034E526 /* ctftools.xcconfig */;
+ 			buildSettings = {
+ 				COPY_PHASE_STRIP = NO;
+ 				DEBUG_INFORMATION_FORMAT = dwarf;
+@@ -13791,6 +13792,7 @@
+ 		};
+ 		6EBC9779099BFB530001019C /* Release */ = {
+ 			isa = XCBuildConfiguration;
++			baseConfigurationReference = 45A48B3618194C410034E526 /* ctftools.xcconfig */;
+ 			buildSettings = {
+ 				COPY_PHASE_STRIP = NO;
+ 				DEBUG_INFORMATION_FORMAT = dwarf;
+@@ -13814,6 +13816,7 @@
+ 		};
+ 		6EBC97E8099BFB850001019C /* Debug */ = {
+ 			isa = XCBuildConfiguration;
++			baseConfigurationReference = 45A48B3618194C410034E526 /* ctftools.xcconfig */;
+ 			buildSettings = {
+ 				COPY_PHASE_STRIP = NO;
+ 				GCC_GENERATE_DEBUGGING_SYMBOLS = YES;
+@@ -13836,6 +13839,7 @@
+ 		};
+ 		6EBC97E9099BFB850001019C /* Release */ = {
+ 			isa = XCBuildConfiguration;
++			baseConfigurationReference = 45A48B3618194C410034E526 /* ctftools.xcconfig */;
+ 			buildSettings = {
+ 				COPY_PHASE_STRIP = NO;
+ 				DEBUG_INFORMATION_FORMAT = dwarf;
+@@ -14037,7 +14041,6 @@
+ 					"$(SDKROOT)/System/Library/Frameworks/System.framework/PrivateHeaders",
+ 					"compat/opensolaris/**",
+ 				);
+-				INSTALL_PATH = "$(DT_TOOLCHAIN_DIR)/usr/local/bin";
+ 				OTHER_CFLAGS = (
+ 					"-D_INT64_TYPE",
+ 					"-D_LONGLONG_TYPE",
+@@ -14072,7 +14075,6 @@
+ 					"$(SDKROOT)/System/Library/Frameworks/System.framework/PrivateHeaders",
+ 					"compat/opensolaris/**",
+ 				);
+-				INSTALL_PATH = "$(DT_TOOLCHAIN_DIR)/usr/local/bin";
+ 				OTHER_CFLAGS = (
+ 					"-D_INT64_TYPE",
+ 					"-D_LONGLONG_TYPE",
+@@ -14109,7 +14111,6 @@
+ 					"$(SDKROOT)/System/Library/Frameworks/System.framework/PrivateHeaders",
+ 					"compat/opensolaris/**",
+ 				);
+-				INSTALL_PATH = "$(DT_TOOLCHAIN_DIR)/usr/local/bin";
+ 				OTHER_CFLAGS = (
+ 					"-D_INT64_TYPE",
+ 					"-D_LONGLONG_TYPE",
+@@ -14143,7 +14144,6 @@
+ 					"$(SDKROOT)/System/Library/Frameworks/System.framework/PrivateHeaders",
+ 					"compat/opensolaris/**",
+ 				);
+-				INSTALL_PATH = "$(DT_TOOLCHAIN_DIR)/usr/local/bin";
+ 				OTHER_CFLAGS = (
+ 					"-D_INT64_TYPE",
+ 					"-D_LONGLONG_TYPE",
+@@ -14163,6 +14163,7 @@
+ 		};
+ 		D2DF085F0A68400000384A72 /* Debug */ = {
+ 			isa = XCBuildConfiguration;
++			baseConfigurationReference = 45A48B3618194C410034E526 /* ctftools.xcconfig */;
+ 			buildSettings = {
+ 				COPY_PHASE_STRIP = NO;
+ 				GCC_DYNAMIC_NO_PIC = NO;
+@@ -14180,6 +14181,7 @@
+ 		};
+ 		D2DF08600A68400000384A72 /* Release */ = {
+ 			isa = XCBuildConfiguration;
++			baseConfigurationReference = 45A48B3618194C410034E526 /* ctftools.xcconfig */;
+ 			buildSettings = {
+ 				COPY_PHASE_STRIP = NO;
+ 				DEBUG_INFORMATION_FORMAT = dwarf;
+@@ -14212,7 +14214,6 @@
+ 					"$(SDKROOT)/System/Library/Frameworks/System.framework/PrivateHeaders",
+ 					"compat/opensolaris/**",
+ 				);
+-				INSTALL_PATH = "$(DT_TOOLCHAIN_DIR)/usr/local/bin";
+ 				OTHER_CFLAGS = (
+ 					"-D_INT64_TYPE",
+ 					"-D_LONGLONG_TYPE",
+@@ -14247,7 +14248,6 @@
+ 					"$(SDKROOT)/System/Library/Frameworks/System.framework/PrivateHeaders",
+ 					"compat/opensolaris/**",
+ 				);
+-				INSTALL_PATH = "$(DT_TOOLCHAIN_DIR)/usr/local/bin";
+ 				OTHER_CFLAGS = (
+ 					"-D_INT64_TYPE",
+ 					"-D_LONGLONG_TYPE",

--- a/patches/libdispatch-1008.220.2-xcodeconfig_BSD.xcconfig.add
+++ b/patches/libdispatch-1008.220.2-xcodeconfig_BSD.xcconfig.add
@@ -1,0 +1,11 @@
+ARCHS = $(ARCHS_STANDARD_32_64_BIT);
+CODE_SIGN_IDENTITY = -;
+CURRENT_PROJECT_VERSION = $(RC_ProjectSourceVersion);
+DEAD_CODE_STRIPPING = YES;
+DEBUG_INFORMATION_FORMAT = dwarf-with-dsym;
+PREBINDING = NO;
+// Current Mac OS
+SDKROOT = macosx;
+//USE_HEADERMAP = NO;
+VERSION_INFO_PREFIX = __attribute__((visibility("hidden"))) __
+VERSIONING_SYSTEM = apple-generic;

--- a/patches/libdispatch-1008.220.2.fix-build.p1.patch
+++ b/patches/libdispatch-1008.220.2.fix-build.p1.patch
@@ -1,0 +1,47 @@
+diff --git a/src/firehose/firehose_inline_internal.h b/src/firehose/firehose_inline_internal.h
+index 64d8654..8051af8 100644
+--- a/src/firehose/firehose_inline_internal.h
++++ b/src/firehose/firehose_inline_internal.h
+@@ -48,6 +48,14 @@ firehose_bitmap_first_set(uint64_t bitmap)
+ }
+ #endif
+ 
++static firehose_chunk_t firehose_buffer_chunk_for_address(void *addr);
++OS_ALWAYS_INLINE static firehose_chunk_t firehose_buffer_ref_to_chunk(firehose_buffer_t fb, firehose_chunk_ref_t ref);
++static uint8_t firehose_buffer_qos_bits_propagate(void);
++static void firehose_buffer_stream_flush(firehose_buffer_t fb, firehose_stream_t stream);
++static void firehose_buffer_tracepoint_flush(firehose_buffer_t fb, firehose_tracepoint_t ft, firehose_tracepoint_id_u ftid);
++firehose_tracepoint_t firehose_buffer_tracepoint_reserve_slow(firehose_buffer_t fb, firehose_tracepoint_query_t ask, uint8_t **privptr);
++OS_NOINLINE void firehose_buffer_ring_enqueue(firehose_buffer_t fb, firehose_chunk_ref_t ref);
++
+ #pragma mark -
+ #pragma mark Mach Misc.
+ #ifndef KERNEL
+@@ -165,7 +173,6 @@ firehose_buffer_ref_to_chunk(firehose_buffer_t fb, firehose_chunk_ref_t ref)
+ 	return fb->fb_chunks + ref;
+ }
+ 
+-#ifndef FIREHOSE_SERVER
+ #if DISPATCH_PURE_C
+ 
+ OS_ALWAYS_INLINE
+@@ -535,8 +542,6 @@ firehose_buffer_bank_relinquish_slot(firehose_buffer_t fb, bool for_io)
+ }
+ #endif // !KERNEL
+ 
+-#endif // !defined(FIREHOSE_SERVER)
+-
+ #endif // DISPATCH_PURE_C
+ 
+ #endif // __FIREHOSE_INLINE_INTERNAL__
+diff --git a/xcodeconfig/libfirehose_kernel.xcconfig b/xcodeconfig/libfirehose_kernel.xcconfig
+index e69108f..bf52cc8 100644
+--- a/xcodeconfig/libfirehose_kernel.xcconfig
++++ b/xcodeconfig/libfirehose_kernel.xcconfig
+@@ -31,3 +31,6 @@ HEADER_SEARCH_PATHS = $(PROJECT_DIR) $(SDKROOT)/System/Library/Frameworks/Kernel
+ 
+ COPY_HEADERS_RUN_UNIFDEF = YES
+ COPY_HEADERS_UNIFDEF_FLAGS = -DKERNEL=1 -DOS_FIREHOSE_SPI=1 -DOS_VOUCHER_ACTIVITY_SPI_TYPES=1 -UOS_VOUCHER_ACTIVITY_SPI
++
++GCC_WARN_ABOUT_MISSING_PROTOTYPES = NO
++WARNING_CFLAGS = $(inherited) -Wno-error=unused-function

--- a/patches/libdispatch-1008.220.2.header-paths.p1.patch
+++ b/patches/libdispatch-1008.220.2.header-paths.p1.patch
@@ -1,0 +1,73 @@
+commit 860148384dbee82df190694ac7a0103f6d3ba704
+Author: William Kent <wjk@users.noreply.github.com>
+Date:   Tue Dec 11 15:04:28 2018 -0500
+
+    Apply patch
+
+diff --git a/xcodeconfig/BSD.xcconfig b/xcodeconfig/BSD.xcconfig
+new file mode 100644
+index 0000000..4348218
+--- /dev/null
++++ b/xcodeconfig/BSD.xcconfig
+@@ -0,0 +1,11 @@
++ARCHS = $(ARCHS_STANDARD_32_64_BIT);
++CODE_SIGN_IDENTITY = -;
++CURRENT_PROJECT_VERSION = $(RC_ProjectSourceVersion);
++DEAD_CODE_STRIPPING = YES;
++DEBUG_INFORMATION_FORMAT = dwarf-with-dsym;
++PREBINDING = NO;
++// Current Mac OS
++SDKROOT = macosx;
++//USE_HEADERMAP = NO;
++VERSION_INFO_PREFIX = __attribute__((visibility("hidden"))) __
++VERSIONING_SYSTEM = apple-generic;
+diff --git a/xcodeconfig/libdispatch.xcconfig b/xcodeconfig/libdispatch.xcconfig
+index 2c825f7..a06ee26 100644
+--- a/xcodeconfig/libdispatch.xcconfig
++++ b/xcodeconfig/libdispatch.xcconfig
+@@ -18,10 +18,8 @@
+ // @APPLE_APACHE_LICENSE_HEADER_END@
+ //
+ 
+-#include "<DEVELOPER_DIR>/Makefiles/CoreOS/Xcode/BSD.xcconfig"
+-#include "<DEVELOPER_DIR>/AppleInternal/XcodeConfig/PlatformSupport.xcconfig"
++#include "BSD.xcconfig"
+ 
+-SDKROOT = macosx.internal
+ SUPPORTED_PLATFORMS = macosx iphoneos iphonesimulator appletvos appletvsimulator watchos watchsimulator
+ PRODUCT_NAME = libdispatch
+ EXECUTABLE_PREFIX =
+diff --git a/xcodeconfig/libfirehose.xcconfig b/xcodeconfig/libfirehose.xcconfig
+index 4c71199..418045d 100644
+--- a/xcodeconfig/libfirehose.xcconfig
++++ b/xcodeconfig/libfirehose.xcconfig
+@@ -18,7 +18,7 @@
+ // @APPLE_APACHE_LICENSE_HEADER_END@
+ //
+ 
+-SUPPORTED_PLATFORMS = macosx iphoneos iphonesimulator appletvos appletvsimulator watchos watchsimulator
++SUPPORTED_PLATFORMS = macosx
+ PRODUCT_NAME = $(TARGET_NAME)
+ INSTALL_PATH = /usr/local/lib/
+ GCC_PREPROCESSOR_DEFINITIONS = $(inherited) FIREHOSE_SERVER=1 DISPATCH_USE_DTRACE=0
+diff --git a/xcodeconfig/libfirehose_kernel.xcconfig b/xcodeconfig/libfirehose_kernel.xcconfig
+index c572f80..e69108f 100644
+--- a/xcodeconfig/libfirehose_kernel.xcconfig
++++ b/xcodeconfig/libfirehose_kernel.xcconfig
+@@ -20,14 +20,14 @@
+ 
+ #include "libfirehose.xcconfig"
+ 
+-SUPPORTED_PLATFORMS = macosx iphoneos appletvos watchos
++SUPPORTED_PLATFORMS = macosx
+ PRODUCT_NAME = $(TARGET_NAME)
+ INSTALL_PATH = /usr/local/lib/kernel/
+ GCC_PREPROCESSOR_DEFINITIONS = $(inherited) KERNEL=1 DISPATCH_USE_DTRACE=0
+ OTHER_CFLAGS = -mkernel -nostdinc -Wno-packed
+ // LLVM_LTO = YES
+ PRIVATE_HEADERS_FOLDER_PATH = /usr/local/include/kernel/os
+-HEADER_SEARCH_PATHS = $(PROJECT_DIR) $(SDKROOT)/System/Library/Frameworks/Kernel.framework/PrivateHeaders $(SDKROOT)/System/Library/Frameworks/Kernel.framework/Headers $(SDKROOT)/usr/local/include/os $(SDKROOT)/usr/local/include/firehose
++HEADER_SEARCH_PATHS = $(PROJECT_DIR) $(SDKROOT)/System/Library/Frameworks/Kernel.framework/PrivateHeaders $(DEPENDENCIES_DIR)/System/Library/Frameworks/Kernel.framework/PrivateHeaders $(DEPENDENCIES_DIR)/usr/local/include/os $(DEPENDENCIES_DIR)/usr/local/include/firehose $(SDKROOT)/usr/include
+ 
+ COPY_HEADERS_RUN_UNIFDEF = YES
+ COPY_HEADERS_UNIFDEF_FLAGS = -DKERNEL=1 -DOS_FIREHOSE_SPI=1 -DOS_VOUCHER_ACTIVITY_SPI_TYPES=1 -UOS_VOUCHER_ACTIVITY_SPI

--- a/patches/libdispatch-1008.220.2.header-paths.p1.patch
+++ b/patches/libdispatch-1008.220.2.header-paths.p1.patch
@@ -1,26 +1,3 @@
-commit 860148384dbee82df190694ac7a0103f6d3ba704
-Author: William Kent <wjk@users.noreply.github.com>
-Date:   Tue Dec 11 15:04:28 2018 -0500
-
-    Apply patch
-
-diff --git a/xcodeconfig/BSD.xcconfig b/xcodeconfig/BSD.xcconfig
-new file mode 100644
-index 0000000..4348218
---- /dev/null
-+++ b/xcodeconfig/BSD.xcconfig
-@@ -0,0 +1,11 @@
-+ARCHS = $(ARCHS_STANDARD_32_64_BIT);
-+CODE_SIGN_IDENTITY = -;
-+CURRENT_PROJECT_VERSION = $(RC_ProjectSourceVersion);
-+DEAD_CODE_STRIPPING = YES;
-+DEBUG_INFORMATION_FORMAT = dwarf-with-dsym;
-+PREBINDING = NO;
-+// Current Mac OS
-+SDKROOT = macosx;
-+//USE_HEADERMAP = NO;
-+VERSION_INFO_PREFIX = __attribute__((visibility("hidden"))) __
-+VERSIONING_SYSTEM = apple-generic;
 diff --git a/xcodeconfig/libdispatch.xcconfig b/xcodeconfig/libdispatch.xcconfig
 index 2c825f7..a06ee26 100644
 --- a/xcodeconfig/libdispatch.xcconfig
@@ -51,7 +28,7 @@ index 4c71199..418045d 100644
  INSTALL_PATH = /usr/local/lib/
  GCC_PREPROCESSOR_DEFINITIONS = $(inherited) FIREHOSE_SERVER=1 DISPATCH_USE_DTRACE=0
 diff --git a/xcodeconfig/libfirehose_kernel.xcconfig b/xcodeconfig/libfirehose_kernel.xcconfig
-index c572f80..e69108f 100644
+index c572f80..72f0549 100644
 --- a/xcodeconfig/libfirehose_kernel.xcconfig
 +++ b/xcodeconfig/libfirehose_kernel.xcconfig
 @@ -20,14 +20,14 @@

--- a/patches/libdispatch-1008.220.2.header-paths.p1.patch
+++ b/patches/libdispatch-1008.220.2.header-paths.p1.patch
@@ -67,7 +67,7 @@ index c572f80..e69108f 100644
  // LLVM_LTO = YES
  PRIVATE_HEADERS_FOLDER_PATH = /usr/local/include/kernel/os
 -HEADER_SEARCH_PATHS = $(PROJECT_DIR) $(SDKROOT)/System/Library/Frameworks/Kernel.framework/PrivateHeaders $(SDKROOT)/System/Library/Frameworks/Kernel.framework/Headers $(SDKROOT)/usr/local/include/os $(SDKROOT)/usr/local/include/firehose
-+HEADER_SEARCH_PATHS = $(PROJECT_DIR) $(SDKROOT)/System/Library/Frameworks/Kernel.framework/PrivateHeaders $(DEPENDENCIES_DIR)/System/Library/Frameworks/Kernel.framework/PrivateHeaders $(DEPENDENCIES_DIR)/usr/local/include/os $(DEPENDENCIES_DIR)/usr/local/include/firehose $(SDKROOT)/usr/include
++HEADER_SEARCH_PATHS = $(PROJECT_DIR) $(SDKROOT)/System/Library/Frameworks/Kernel.framework/PrivateHeaders $(DEPROOT)/System/Library/Frameworks/Kernel.framework/PrivateHeaders $(DEPROOT)/usr/local/include/os $(DEPROOT)/usr/local/include/firehose $(SDKROOT)/usr/include
  
  COPY_HEADERS_RUN_UNIFDEF = YES
  COPY_HEADERS_UNIFDEF_FLAGS = -DKERNEL=1 -DOS_FIREHOSE_SPI=1 -DOS_VOUCHER_ACTIVITY_SPI_TYPES=1 -UOS_VOUCHER_ACTIVITY_SPI

--- a/patches/libplatform-177-20.16.xnu-headers.p1.patch
+++ b/patches/libplatform-177-20.16.xnu-headers.p1.patch
@@ -1,0 +1,12 @@
+diff --git a/Makefile b/Makefile
+new file mode 100644
+index 0000000..4ad38d4
+--- /dev/null
++++ b/Makefile
+@@ -0,0 +1,6 @@
++# Barebones makefile for libplatform_xnu_headers
++# darwinbuild project, not to be used elsewhere.
++.PHONY : installhdrs
++installhdrs :
++	ditto $(SRCROOT)/include $(DSTROOT)/usr/local/include
++	ditto $(SRCROOT)/private $(DSTROOT)/usr/local/include

--- a/patches/xnu-4903.221.2.availability_versions.p1.patch
+++ b/patches/xnu-4903.221.2.availability_versions.p1.patch
@@ -1,0 +1,33 @@
+diff --git a/bsd/sys/make_symbol_aliasing.sh b/bsd/sys/make_symbol_aliasing.sh
+index ef47e37..a1e694a 100755
+--- a/bsd/sys/make_symbol_aliasing.sh
++++ b/bsd/sys/make_symbol_aliasing.sh
+@@ -34,8 +34,8 @@ fi
+ SDKROOT="$1"
+ OUTPUT="$2"
+
+-if [ ! -x "${SDKROOT}/usr/local/libexec/availability.pl" ] ; then
+-    echo "Unable to locate ${SDKROOT}/usr/local/libexec/availability.pl (or not executable)" >&2
++if [ ! -x "${DEPENDENCIES_DIR}/usr/local/libexec/availability.pl" ] ; then
++    echo "Unable to locate ${DEPENDENCIES_DIR}/usr/local/libexec/availability.pl (or not executable)" >&2
+     exit 1
+ fi
+
+@@ -74,7 +74,7 @@ cat <<EOF
+
+ EOF
+
+-for ver in $(${SDKROOT}/usr/local/libexec/availability.pl --ios) ; do
++for ver in $(${DEPENDENCIES_DIR}/usr/local/libexec/availability.pl --ios) ; do
+     ver_major=${ver%.*}
+     ver_minor=${ver#*.}
+     value=$(printf "%d%02d00" ${ver_major} ${ver_minor})
+@@ -87,7 +87,7 @@ for ver in $(${SDKROOT}/usr/local/libexec/availability.pl --ios) ; do
+     echo ""
+ done
+
+-for ver in $(${SDKROOT}/usr/local/libexec/availability.pl --macosx) ; do
++for ver in $(${DEPENDENCIES_DIR}/usr/local/libexec/availability.pl --macosx) ; do
+     set -- $(echo "$ver" | tr '.' ' ')
+     ver_major=$1
+     ver_minor=$2

--- a/patches/xnu-4903.221.2.availability_versions.p1.patch
+++ b/patches/xnu-4903.221.2.availability_versions.p1.patch
@@ -8,8 +8,8 @@ index ef47e37..a1e694a 100755
 
 -if [ ! -x "${SDKROOT}/usr/local/libexec/availability.pl" ] ; then
 -    echo "Unable to locate ${SDKROOT}/usr/local/libexec/availability.pl (or not executable)" >&2
-+if [ ! -x "${DEPENDENCIES_DIR}/usr/local/libexec/availability.pl" ] ; then
-+    echo "Unable to locate ${DEPENDENCIES_DIR}/usr/local/libexec/availability.pl (or not executable)" >&2
++if [ ! -x "${DEPROOT}/usr/local/libexec/availability.pl" ] ; then
++    echo "Unable to locate ${DEPROOT}/usr/local/libexec/availability.pl (or not executable)" >&2
      exit 1
  fi
 
@@ -18,7 +18,7 @@ index ef47e37..a1e694a 100755
  EOF
 
 -for ver in $(${SDKROOT}/usr/local/libexec/availability.pl --ios) ; do
-+for ver in $(${DEPENDENCIES_DIR}/usr/local/libexec/availability.pl --ios) ; do
++for ver in $(${DEPROOT}/usr/local/libexec/availability.pl --ios) ; do
      ver_major=${ver%.*}
      ver_minor=${ver#*.}
      value=$(printf "%d%02d00" ${ver_major} ${ver_minor})
@@ -27,7 +27,7 @@ index ef47e37..a1e694a 100755
  done
 
 -for ver in $(${SDKROOT}/usr/local/libexec/availability.pl --macosx) ; do
-+for ver in $(${DEPENDENCIES_DIR}/usr/local/libexec/availability.pl --macosx) ; do
++for ver in $(${DEPROOT}/usr/local/libexec/availability.pl --macosx) ; do
      set -- $(echo "$ver" | tr '.' ' ')
      ver_major=$1
      ver_minor=$2

--- a/patches/xnu-4903.221.2.bsd-xcconfig.p1.patch
+++ b/patches/xnu-4903.221.2.bsd-xcconfig.p1.patch
@@ -1,0 +1,20 @@
+diff --git a/libsyscall/Libsyscall.xcconfig b/libsyscall/Libsyscall.xcconfig
+index 09d1119..e668e49 100644
+--- a/libsyscall/Libsyscall.xcconfig
++++ b/libsyscall/Libsyscall.xcconfig
+@@ -1,4 +1,14 @@
+-#include "<DEVELOPER_DIR>/Makefiles/CoreOS/Xcode/BSD.xcconfig"
++// From BSD.xcconfig
++ARCHS = $(ARCHS_STANDARD);
++CODE_SIGN_IDENTITY = -;
++CURRENT_PROJECT_VERSION = $(RC_ProjectSourceVersion);
++DEAD_CODE_STRIPPING = YES;
++DEBUG_INFORMATION_FORMAT = dwarf-with-dsym;
++PREBINDING = NO;
++SDKROOT = macosx;
++VERSION_INFO_PREFIX = __;
++VERSIONING_SYSTEM = apple-generic;
++// End BSD.xcconfig
+ 
+ BUILD_VARIANTS = normal
+ SUPPORTED_PLATFORMS = macosx iphoneos iphoneosnano tvos appletvos watchos bridgeos

--- a/patches/xnu-4903.221.2.fix_codesigning.p1.patch
+++ b/patches/xnu-4903.221.2.fix_codesigning.p1.patch
@@ -1,0 +1,91 @@
+diff --git a/SETUP/config/Makefile b/SETUP/config/Makefile
+index 56032b4..1e73452 100644
+--- a/SETUP/config/Makefile
++++ b/SETUP/config/Makefile
+@@ -20,7 +20,7 @@ config: $(OBJS)
+ 	@echo "$(ColorH)HOST_LD$(Color0)       $(ColorF)$@$(Color0)"
+ 	$(_v)$(HOST_CC) $(LDFLAGS) -o $@ $^
+ 	@echo "$(ColorH)HOST_CODESIGN$(Color0) $(ColorF)$@$(Color0)"
+-	$(_v)env CODESIGN_ALLOCATE=$(HOST_CODESIGN_ALLOCATE) $(HOST_CODESIGN) -s - $@
++	$(_v)env $(HOST_CODESIGN) -s - $@
+ 
+ %.o: %.c
+ 	@echo "$(ColorH)HOST_CC$(Color0)       $(ColorF)$@$(Color0)"
+diff --git a/SETUP/decomment/Makefile b/SETUP/decomment/Makefile
+index 7018eb1..877ca15 100644
+--- a/SETUP/decomment/Makefile
++++ b/SETUP/decomment/Makefile
+@@ -18,7 +18,7 @@ decomment: $(OBJS)
+ 	@echo "$(ColorH)HOST_LD$(Color0)       $(ColorF)$@$(Color0)"
+ 	$(_v)$(HOST_CC) $(LDFLAGS) -o $@ $^
+ 	@echo "$(ColorH)HOST_CODESIGN$(Color0) $(ColorF)$@$(Color0)"
+-	$(_v)env CODESIGN_ALLOCATE=$(HOST_CODESIGN_ALLOCATE) $(HOST_CODESIGN) -s - $@
++	$(_v)env $(HOST_CODESIGN) -s - $@
+ 
+ %.o: %.c
+ 	@echo "$(ColorH)HOST_CC$(Color0)       $(ColorF)$@$(Color0)"
+diff --git a/SETUP/installfile/Makefile b/SETUP/installfile/Makefile
+index eb1f3af..a74b483 100644
+--- a/SETUP/installfile/Makefile
++++ b/SETUP/installfile/Makefile
+@@ -18,7 +18,7 @@ installfile: $(OBJS)
+ 	@echo "$(ColorH)HOST_LD$(Color0)       $(ColorF)$@$(Color0)"
+ 	$(_v)$(HOST_CC) $(LDFLAGS) -o $@ $^
+ 	@echo "$(ColorH)HOST_CODESIGN$(Color0) $(ColorF)$@$(Color0)"
+-	$(_v)env CODESIGN_ALLOCATE=$(HOST_CODESIGN_ALLOCATE) $(HOST_CODESIGN) -s - $@
++	$(_v)env $(HOST_CODESIGN) -s - $@
+ 
+ %.o: %.c
+ 	@echo "$(ColorH)HOST_CC$(Color0)       $(ColorF)$@$(Color0)"
+diff --git a/SETUP/json_compilation_db/Makefile b/SETUP/json_compilation_db/Makefile
+index 518644c..bf453c3 100644
+--- a/SETUP/json_compilation_db/Makefile
++++ b/SETUP/json_compilation_db/Makefile
+@@ -18,7 +18,7 @@ json_compilation_db: $(OBJS)
+ 	@echo "$(ColorH)HOST_LD$(Color0)       $(ColorF)$@$(Color0)"
+ 	$(_v)$(HOST_CC) $(LDFLAGS) -o $@ $^
+ 	@echo "$(ColorH)HOST_CODESIGN$(Color0) $(ColorF)$@$(Color0)"
+-	$(_v)env CODESIGN_ALLOCATE=$(HOST_CODESIGN_ALLOCATE) $(HOST_CODESIGN) -s - $@
++	$(_v)env $(HOST_CODESIGN) -s - $@
+ 
+ %.o: %.c
+ 	@echo "$(ColorH)HOST_CC$(Color0)       $(ColorF)$@$(Color0)"
+diff --git a/SETUP/kextsymboltool/Makefile b/SETUP/kextsymboltool/Makefile
+index af6cdca..e38782f 100644
+--- a/SETUP/kextsymboltool/Makefile
++++ b/SETUP/kextsymboltool/Makefile
+@@ -18,7 +18,7 @@ kextsymboltool: $(OBJS)
+ 	@echo "$(ColorH)HOST_LD$(Color0)       $(ColorF)$@$(Color0)"
+ 	$(_v)$(HOST_CC) $(LDFLAGS) -o $@ $^
+ 	@echo "$(ColorH)HOST_CODESIGN$(Color0) $(ColorF)$@$(Color0)"
+-	$(_v)env CODESIGN_ALLOCATE=$(HOST_CODESIGN_ALLOCATE) $(HOST_CODESIGN) -s - $@
++	$(_v)env $(HOST_CODESIGN) -s - $@
+ 
+ %.o: %.c
+ 	@echo "$(ColorH)HOST_CC$(Color0)       $(ColorF)$@$(Color0)"
+diff --git a/SETUP/replacecontents/Makefile b/SETUP/replacecontents/Makefile
+index e1e8484..44b81b9 100644
+--- a/SETUP/replacecontents/Makefile
++++ b/SETUP/replacecontents/Makefile
+@@ -18,7 +18,7 @@ replacecontents: $(OBJS)
+ 	@echo "$(ColorH)HOST_LD$(Color0)       $(ColorF)$@$(Color0)"
+ 	$(_v)$(HOST_CC) $(LDFLAGS) -o $@ $^
+ 	@echo "$(ColorH)HOST_CODESIGN$(Color0) $(ColorF)$@$(Color0)"
+-	$(_v)env CODESIGN_ALLOCATE=$(HOST_CODESIGN_ALLOCATE) $(HOST_CODESIGN) -s - $@
++	$(_v)env $(HOST_CODESIGN) -s - $@
+ 
+ %.o: %.c
+ 	@echo "$(ColorH)HOST_CC$(Color0)       $(ColorF)$@$(Color0)"
+diff --git a/SETUP/setsegname/Makefile b/SETUP/setsegname/Makefile
+index 7e9224e..c2ed335 100644
+--- a/SETUP/setsegname/Makefile
++++ b/SETUP/setsegname/Makefile
+@@ -18,7 +18,7 @@ setsegname: $(OBJS)
+ 	@echo "$(ColorH)HOST_LD$(Color0)       $(ColorF)$@$(Color0)"
+ 	$(_v)$(HOST_CC) $(LDFLAGS) -o $@ $^
+ 	@echo "$(ColorH)HOST_CODESIGN$(Color0) $(ColorF)$@$(Color0)"
+-	$(_v)env CODESIGN_ALLOCATE=$(HOST_CODESIGN_ALLOCATE) $(HOST_CODESIGN) -s - $@
++	$(_v)env $(HOST_CODESIGN) -s - $@
+ 
+ %.o: %.c
+ 	@echo "$(ColorH)HOST_CC$(Color0)       $(ColorF)$@$(Color0)"

--- a/patches/xnu-4903.221.2.fix_system_framework.p1.patch
+++ b/patches/xnu-4903.221.2.fix_system_framework.p1.patch
@@ -1,0 +1,26 @@
+diff --git a/makedefs/MakeInc.kernel b/makedefs/MakeInc.kernel
+index 55de6d3..b0a63cf 100644
+--- a/makedefs/MakeInc.kernel
++++ b/makedefs/MakeInc.kernel
+@@ -345,6 +345,21 @@ do_installhdrs_mi:: $(DSTROOT)/$(KRESDIR)/Info.plist
+ 	$(_v)$(RM) $(DSTROOT)/$(KINCFRAME)/Resources
+ 	$(_v)$(LN) Versions/Current/Resources			\
+ 		   $(DSTROOT)/$(KINCFRAME)/Resources
++	$(_v)$(RM) $(DSTROOT)/$(SINCFRAME)/Versions/Current
++	$(_v)$(LN) $(SINCVERS) \
++		   $(DSTROOT)/$(SINCFRAME)/Versions/Current
++	$(_v)$(RM) $(DSTROOT)/$(SINCFRAME)/PrivateHeaders
++	$(_v)$(LN) Versions/Current/PrivateHeaders		\
++		   $(DSTROOT)/$(SINCFRAME)/PrivateHeaders
++	$(_v)$(RM) $(DSTROOT)/$(SINCFRAME)/Resources
++	$(_v)$(LN) Versions/Current/Resources			\
++		   $(DSTROOT)/$(SINCFRAME)/Resources
++	$(_v)$(RM) $(DSTROOT)/System/Library/Frameworks/IOKit.framework/Versions/Current
++	$(_v)$(LN) A $(DSTROOT)/System/Library/Frameworks/IOKit.framework/Versions/Current
++	$(_v)$(RM) $(DSTROOT)/System/Library/Frameworks/IOKit.framework/Headers
++	$(_v)$(LN) Versions/Current/Headers $(DSTROOT)/System/Library/Frameworks/IOKit.framework/Headers
++	$(_v)$(RM) $(DSTROOT)/System/Library/Frameworks/IOKit.framework/PrivateHeaders
++	$(_v)$(LN) Versions/Current/PrivateHeaders $(DSTROOT)/System/Library/Frameworks/IOKit.framework/PrivateHeaders
+ 
+ $(DSTROOT)/$(KRESDIR)/Info.plist: $(SOURCE)/EXTERNAL_HEADERS/Info.plist
+ 	$(_v)$(MKDIR) $(DSTROOT)/$(KRESDIR)

--- a/patches/xnu-4903.221.2.kext_copyright_check.p1.patch
+++ b/patches/xnu-4903.221.2.kext_copyright_check.p1.patch
@@ -1,0 +1,22 @@
+diff --git a/libkern/kxld/kxld_copyright.c b/libkern/kxld/kxld_copyright.c
+index e1f13c2..8664226 100644
+--- a/libkern/kxld/kxld_copyright.c
++++ b/libkern/kxld/kxld_copyright.c
+@@ -49,6 +49,7 @@
+ 
+ #define kCopyrightToken "Copyright © "
+ #define kRightsToken " Apple Inc. All rights reserved."
++#define kRightsTokenPD " PureDarwin Project. All rights reserved."
+ 
+ /******************************************************************************
+ * Globals
+@@ -252,6 +253,9 @@ kxld_validate_copyright_string(const char *str)
+ 
+     copyright = kxld_strstr(str, kCopyrightToken);
+     rights = kxld_strstr(str, kRightsToken);
++    if (!rights) {
++        rights = kxld_strstr(str, kRightsTokenPD);
++    }
+ 
+     if (!copyright || !rights || copyright > rights) goto finish;
+ 

--- a/patches/xnu-4903.221.2.libsyscall-build.p1.patch
+++ b/patches/xnu-4903.221.2.libsyscall-build.p1.patch
@@ -1,0 +1,260 @@
+diff --git a/libsyscall/Libsyscall.xcconfig b/libsyscall/Libsyscall.xcconfig
+index 737c410..349ff77 100644
+--- a/libsyscall/Libsyscall.xcconfig
++++ b/libsyscall/Libsyscall.xcconfig
+@@ -21,10 +19,10 @@ OTHER_CFLAGS[sdk=watchos*] = $(inherited) -DNO_SYSCALL_LEGACY
+ OTHER_CFLAGS[sdk=tvos*] = $(inherited) -DNO_SYSCALL_LEGACY
+ OTHER_CFLAGS[sdk=appletvos*] = $(inherited) -DNO_SYSCALL_LEGACY
+ OTHER_CFLAGS[sdk=bridgeos*] = $(inherited) -DNO_SYSCALL_LEGACY
+-GCC_PREPROCESSOR_DEFINITIONS = CF_OPEN_SOURCE CF_EXCLUDE_CSTD_HEADERS DEBUG _FORTIFY_SOURCE=0
+-HEADER_SEARCH_PATHS = $(PROJECT_DIR)/mach $(PROJECT_DIR)/os $(PROJECT_DIR)/wrappers $(PROJECT_DIR)/wrappers/string $(PROJECT_DIR)/wrappers/libproc $(PROJECT_DIR)/wrappers/libproc/spawn $(BUILT_PRODUCTS_DIR)/internal_hdr/include $(BUILT_PRODUCTS_DIR)/mig_hdr/local/include $(BUILT_PRODUCTS_DIR)/mig_hdr/include $(SDKROOT)/System/Library/Frameworks/System.framework/PrivateHeaders
++GCC_PREPROCESSOR_DEFINITIONS = CF_OPEN_SOURCE CF_EXCLUDE_CSTD_HEADERS DEBUG _FORTIFY_SOURCE=0 __PUREDARWIN__=1
++HEADER_SEARCH_PATHS = $(PROJECT_DIR)/mach $(PROJECT_DIR)/os $(PROJECT_DIR)/wrappers $(PROJECT_DIR)/wrappers/string $(PROJECT_DIR)/wrappers/libproc $(PROJECT_DIR)/wrappers/libproc/spawn $(BUILT_PRODUCTS_DIR)/internal_hdr/include $(BUILT_PRODUCTS_DIR)/mig_hdr/local/include $(BUILT_PRODUCTS_DIR)/mig_hdr/include $(DEPENDENCIES_DIR)/System/Library/Frameworks/System.framework/PrivateHeaders
++FRAMEWORK_SEARCH_PATHS = $(DEPENDENCIES_DIR)/System/Library/Frameworks
+ WARNING_CFLAGS = -Wmost
+-GCC_TREAT_WARNINGS_AS_ERRORS = YES
+ GCC_WARN_ABOUT_MISSING_NEWLINE = YES
+ CODE_SIGN_IDENTITY = -
+ DYLIB_CURRENT_VERSION = $(RC_ProjectSourceVersion)
+diff --git a/libsyscall/Libsyscall.xcodeproj/project.pbxproj b/libsyscall/Libsyscall.xcodeproj/project.pbxproj
+index e138202..6d6515a 100644
+--- a/libsyscall/Libsyscall.xcodeproj/project.pbxproj
++++ b/libsyscall/Libsyscall.xcodeproj/project.pbxproj
+@@ -23,7 +23,7 @@
+ 			isa = PBXAggregateTarget;
+ 			buildConfigurationList = 249C61191194756B00ED73F3 /* Build configuration list for PBXAggregateTarget "Build" */;
+ 			buildPhases = (
+-				BAFE90DF1C3A4D7B0012084F /* CopyFiles */,
++				BAFE90DF1C3A4D7B0012084F /* Copy Files */,
+ 				BAFE90E11C3A4D9E0012084F /* CopyFiles */,
+ 				BAA2D2FB1C3B2CD90049DCBE /* CopyFiles */,
+ 			);
+@@ -145,7 +145,7 @@
+ 		9C6DA3D320A3D09F0090330B /* mach_sync_ipc.h in Headers */ = {isa = PBXBuildFile; fileRef = 9C6DA3D120A3D09F0090330B /* mach_sync_ipc.h */; };
+ 		9CCF28271E68E993002EE6CD /* pid_shutdown_networking.c in Sources */ = {isa = PBXBuildFile; fileRef = 9CCF28261E68E993002EE6CD /* pid_shutdown_networking.c */; };
+ 		A50845861DDA69AC0041C0E0 /* thread_self_restrict.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = A50BD52E1DDA548F006622C8 /* thread_self_restrict.h */; };
+-		A50845871DDA69C90041C0E0 /* thread_self_restrict.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = A50BD52E1DDA548F006622C8 /* thread_self_restrict.h */; };
++		A50845871DDA69C90041C0E0 /* thread_self_restrict.h in Copy Files */ = {isa = PBXBuildFile; fileRef = A50BD52E1DDA548F006622C8 /* thread_self_restrict.h */; };
+ 		A50BD52F1DDA548F006622C8 /* thread_self_restrict.h in Headers */ = {isa = PBXBuildFile; fileRef = A50BD52E1DDA548F006622C8 /* thread_self_restrict.h */; };
+ 		A50BD5301DDA5500006622C8 /* thread_self_restrict.h in Headers */ = {isa = PBXBuildFile; fileRef = A50BD52E1DDA548F006622C8 /* thread_self_restrict.h */; };
+ 		A59CB95616669EFB00B064B3 /* stack_logging_internal.h in Headers */ = {isa = PBXBuildFile; fileRef = A59CB95516669DB700B064B3 /* stack_logging_internal.h */; };
+@@ -153,7 +153,7 @@
+ 		BA0D9FB1199031AD007E8A73 /* kdebug_trace.c in Sources */ = {isa = PBXBuildFile; fileRef = BA0D9FB0199031AD007E8A73 /* kdebug_trace.c */; };
+ 		BA4414AA18336A5F00AAE813 /* mach in CopyFiles */ = {isa = PBXBuildFile; fileRef = BA4414A51833697C00AAE813 /* mach */; };
+ 		BA4414AB18336A6400AAE813 /* servers in CopyFiles */ = {isa = PBXBuildFile; fileRef = BA4414A6183369A100AAE813 /* servers */; };
+-		BA4414AD18336A9300AAE813 /* mach in CopyFiles */ = {isa = PBXBuildFile; fileRef = BA4414A7183369C100AAE813 /* mach */; };
++		BA4414AD18336A9300AAE813 /* mach in Copy Files */ = {isa = PBXBuildFile; fileRef = BA4414A7183369C100AAE813 /* mach */; };
+ 		BA4414B518336E3600AAE813 /* mach in Copy Files */ = {isa = PBXBuildFile; fileRef = BA4414A51833697C00AAE813 /* mach */; };
+ 		BA4414B618336E3A00AAE813 /* servers in Copy Files */ = {isa = PBXBuildFile; fileRef = BA4414A6183369A100AAE813 /* servers */; };
+ 		BA4414B818336E6F00AAE813 /* mach in CopyFiles */ = {isa = PBXBuildFile; fileRef = BA4414A7183369C100AAE813 /* mach */; };
+@@ -161,7 +161,7 @@
+ 		BAA2D2FC1C3B2CE90049DCBE /* libsystem_kernel.a in CopyFiles */ = {isa = PBXBuildFile; fileRef = D2AAC0630554660B00DB518D /* libsystem_kernel.a */; };
+ 		BABA36CB1A856C4700BBBCF7 /* host.c in Sources */ = {isa = PBXBuildFile; fileRef = BABA36CA1A856C4700BBBCF7 /* host.c */; };
+ 		BAFE90DE1C3A4D2D0012084F /* _libkernel_init.c in Sources */ = {isa = PBXBuildFile; fileRef = 247A08B311F8B05900E4693F /* _libkernel_init.c */; };
+-		BAFE90E01C3A4D960012084F /* libsystem_kernel.a in CopyFiles */ = {isa = PBXBuildFile; fileRef = D2AAC0630554660B00DB518D /* libsystem_kernel.a */; };
++		BAFE90E01C3A4D960012084F /* libsystem_kernel.a in Copy Files */ = {isa = PBXBuildFile; fileRef = D2AAC0630554660B00DB518D /* libsystem_kernel.a */; };
+ 		BAFE90E21C3A4DB00012084F /* libsystem_kernel.a in CopyFiles */ = {isa = PBXBuildFile; fileRef = D2AAC0630554660B00DB518D /* libsystem_kernel.a */; };
+ 		C639F0E51741C25800A39F47 /* gethostuuid.h in Headers */ = {isa = PBXBuildFile; fileRef = C639F0E41741C09A00A39F47 /* gethostuuid.h */; settings = {ATTRIBUTES = (Public, ); }; };
+ 		C6460B7C182025DF00F73CCA /* sfi.c in Sources */ = {isa = PBXBuildFile; fileRef = C6460B7B182025DF00F73CCA /* sfi.c */; };
+@@ -248,7 +248,7 @@
+ 		C9D9BD57114B00600000D8B9 /* task.defs in Sources */ = {isa = PBXBuildFile; fileRef = C9D9BD0F114B00600000D8B9 /* task.defs */; };
+ 		C9D9BD58114B00600000D8B9 /* thread_act.defs in Sources */ = {isa = PBXBuildFile; fileRef = C9D9BD10114B00600000D8B9 /* thread_act.defs */; };
+ 		C9D9BD59114B00600000D8B9 /* vm_map.defs in Sources */ = {isa = PBXBuildFile; fileRef = C9D9BD11114B00600000D8B9 /* vm_map.defs */; };
+-		C9FD8508166D6BD400963B73 /* tsd.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = C9EE57F51669673D00337E4B /* tsd.h */; };
++		C9FD8508166D6BD400963B73 /* tsd.h in Copy Files */ = {isa = PBXBuildFile; fileRef = C9EE57F51669673D00337E4B /* tsd.h */; };
+ 		E214BDC81C2E358300CEE8A3 /* clonefile.c in Sources */ = {isa = PBXBuildFile; fileRef = E214BDC71C2E34E200CEE8A3 /* clonefile.c */; };
+ 		E2A0F3341C3B17D100A11F8A /* fs_snapshot.c in Sources */ = {isa = PBXBuildFile; fileRef = E2A0F3331C3B17D100A11F8A /* fs_snapshot.c */; };
+ 		E4216C311822D404006F2632 /* mach_voucher.defs in Sources */ = {isa = PBXBuildFile; fileRef = E4216C301822D404006F2632 /* mach_voucher.defs */; };
+@@ -327,14 +327,15 @@
+ 			);
+ 			runOnlyForDeploymentPostprocessing = 1;
+ 		};
+-		BA4414AC18336A7700AAE813 /* CopyFiles */ = {
++		BA4414AC18336A7700AAE813 /* Copy Files */ = {
+ 			isa = PBXCopyFilesBuildPhase;
+ 			buildActionMask = 8;
+ 			dstPath = "$(PRIVATE_HEADERS_FOLDER_PATH)";
+ 			dstSubfolderSpec = 0;
+ 			files = (
+-				BA4414AD18336A9300AAE813 /* mach in CopyFiles */,
++				BA4414AD18336A9300AAE813 /* mach in Copy Files */,
+ 			);
++			name = "Copy Files";
+ 			runOnlyForDeploymentPostprocessing = 1;
+ 		};
+ 		BA4414B418336E1A00AAE813 /* Copy Files */ = {
+@@ -370,14 +371,15 @@
+ 			);
+ 			runOnlyForDeploymentPostprocessing = 1;
+ 		};
+-		BAFE90DF1C3A4D7B0012084F /* CopyFiles */ = {
++		BAFE90DF1C3A4D7B0012084F /* Copy Files */ = {
+ 			isa = PBXCopyFilesBuildPhase;
+ 			buildActionMask = 8;
+ 			dstPath = /usr/local/lib/dyld_stub;
+ 			dstSubfolderSpec = 0;
+ 			files = (
+-				BAFE90E01C3A4D960012084F /* libsystem_kernel.a in CopyFiles */,
++				BAFE90E01C3A4D960012084F /* libsystem_kernel.a in Copy Files */,
+ 			);
++			name = "Copy Files";
+ 			runOnlyForDeploymentPostprocessing = 1;
+ 		};
+ 		BAFE90E11C3A4D9E0012084F /* CopyFiles */ = {
+@@ -390,15 +392,16 @@
+ 			);
+ 			runOnlyForDeploymentPostprocessing = 1;
+ 		};
+-		C63F480B1654203800A1F78F /* CopyFiles */ = {
++		C63F480B1654203800A1F78F /* Copy Files */ = {
+ 			isa = PBXCopyFilesBuildPhase;
+ 			buildActionMask = 8;
+ 			dstPath = "$(OS_PRIVATE_HEADERS_FOLDER_PATH)";
+ 			dstSubfolderSpec = 0;
+ 			files = (
+-				A50845871DDA69C90041C0E0 /* thread_self_restrict.h in CopyFiles */,
+-				C9FD8508166D6BD400963B73 /* tsd.h in CopyFiles */,
++				A50845871DDA69C90041C0E0 /* thread_self_restrict.h in Copy Files */,
++				C9FD8508166D6BD400963B73 /* tsd.h in Copy Files */,
+ 			);
++			name = "Copy Files";
+ 			runOnlyForDeploymentPostprocessing = 1;
+ 		};
+ 		C6D3EFCA16542C510052CF30 /* CopyFiles */ = {
+@@ -1204,9 +1207,9 @@
+ 			buildConfigurationList = 1DEB914A08733D8E0010E9CD /* Build configuration list for PBXNativeTarget "Libsyscall_static" */;
+ 			buildPhases = (
+ 				D2AAC0600554660B00DB518D /* Headers */,
+-				C63F480B1654203800A1F78F /* CopyFiles */,
++				C63F480B1654203800A1F78F /* Copy Files */,
+ 				BA4414A818336A1300AAE813 /* CopyFiles */,
+-				BA4414AC18336A7700AAE813 /* CopyFiles */,
++				BA4414AC18336A7700AAE813 /* Copy Files */,
+ 				D2AAC0610554660B00DB518D /* Sources */,
+ 				D289988505E68E00004EDB86 /* Frameworks */,
+ 			);
+diff --git a/libsyscall/mach/err_iokit.sub b/libsyscall/mach/err_iokit.sub
+index b5361b8..c638be6 100644
+--- a/libsyscall/mach/err_iokit.sub
++++ b/libsyscall/mach/err_iokit.sub
+@@ -29,7 +29,7 @@
+ 
+ #include <TargetConditionals.h>
+ #include <IOKit/IOReturn.h>
+-#if !TARGET_OS_EMBEDDED
++#if !TARGET_OS_EMBEDDED && !defined(__PUREDARWIN__)
+ #include <IOKit/usb/USB.h>
+ #include <IOKit/firewire/IOFireWireLib.h>
+ #endif
+@@ -97,7 +97,7 @@ static const char * const err_codes_iokit_common[] = {
+     "(iokit/common) data was not found",				// 0x2f0
+ };
+ 
+-#if !TARGET_OS_EMBEDDED
++#if !TARGET_OS_EMBEDDED && !defined(__PUREDARWIN__)
+ static const struct error_sparse_map err_codes_iokit_usb_map[] = {
+     err_code_map_entry(kIOUSBCRCErr, kIOUSBDataToggleErr),
+     err_code_map_entry(kIOUSBPIDCheckErr, kIOUSBWrongPIDErr),
+@@ -220,7 +220,7 @@ static const struct error_subsystem err_iokit_sub[] =
+ 	err_codes_iokit_common_map,
+ 	errlib_count(err_codes_iokit_common_map),
+     },
+-#if !TARGET_OS_EMBEDDED
++#if !TARGET_OS_EMBEDDED && !defined(__PUREDARWIN__)
+     /*  1 */ {
+ 	"(iokit/usb)",				// 0xe0004000
+ 	errlib_count(err_codes_iokit_usb),
+@@ -241,7 +241,7 @@ static const struct error_subsystem err_iokit_sub[] =
+     /*  5 */ { "(iokit/graphics)",   0 },	// 0xe0014000
+     /*  6 */ err_iokit_null_sub,		// 0xe0018000
+     /*  7 */ err_iokit_null_sub,		// 0xe001c000
+-#if !TARGET_OS_EMBEDDED
++#if !TARGET_OS_EMBEDDED && !defined(__PUREDARWIN__)
+     /*  8 */ {
+ 	"(iokit/bluetooth)",			// 0xe0020000
+ 	errlib_count(err_codes_iokit_bluetooth),
+diff --git a/libsyscall/mach/mach_error.c b/libsyscall/mach/mach_error.c
+index 4b95427..04037a4 100644
+--- a/libsyscall/mach/mach_error.c
++++ b/libsyscall/mach/mach_error.c
+@@ -60,6 +60,7 @@
+  *      or returns a descriptive string.
+  */
+ 
++#include <sys/reason.h>
+ #include <mach/mach_error.h>
+ #include <mach/boolean.h>
+ #include "errorlib.h"
+@@ -83,3 +84,13 @@ mach_error(const char *str, mach_error_t err)
+ 
+ 	fprintf_stderr("%s %s\n", str, err_str);
+ }
++
++void
++_mach_assert(const char *reason, kern_return_t kr)
++{
++	if (kr != KERN_SUCCESS)
++	{
++		// FIXME: What reason code should I use here instead of -1?
++		abort_with_reason(OS_REASON_LIBSYSTEM, -1, reason, OS_REASON_FLAG_GENERATE_CRASH_REPORT);
++	}
++}
+diff --git a/libsyscall/mach/mach_right.c b/libsyscall/mach/mach_right.c
+index c69133e..8c30f83 100644
+--- a/libsyscall/mach/mach_right.c
++++ b/libsyscall/mach/mach_right.c
+@@ -30,6 +30,8 @@
+ #include <mach/mach_port.h>
+ #include <mach/mach_right.h>
+ 
++// From <os/internal/crashlog.h>
++#define _os_set_crash_log_cause_and_message(ac, msg) ((void)(ac), (void)(msg))
+ 
+ #pragma mark Utilities
+ #define _assert_mach(__op, __kr) \
+diff --git a/libsyscall/wrappers/mach_bridge_remote_time.c b/libsyscall/wrappers/mach_bridge_remote_time.c
+index cc56a81..3ba73a2 100644
+--- a/libsyscall/wrappers/mach_bridge_remote_time.c
++++ b/libsyscall/wrappers/mach_bridge_remote_time.c
+@@ -20,6 +20,7 @@
+  *
+  * @APPLE_LICENSE_HEADER_END@
+  */
++#if TARGET_OS_BRIDGE && defined(__arm64__)
+ #include <sys/types.h>
+ #include <machine/cpu_capabilities.h>
+ #include <kern/remote_time.h>
+@@ -31,7 +32,6 @@
+ 
+ extern uint64_t __mach_bridge_remote_time(uint64_t local_time);
+ 
+-#if TARGET_OS_BRIDGE && defined(__arm64__)
+ static uint64_t
+ absolutetime_to_nanoseconds(uint64_t abs_time)
+ {
+diff --git a/libsyscall/wrappers/spawn/posix_spawn.c b/libsyscall/wrappers/spawn/posix_spawn.c
+index 2008380..04b2a2a 100644
+--- a/libsyscall/wrappers/spawn/posix_spawn.c
++++ b/libsyscall/wrappers/spawn/posix_spawn.c
+@@ -28,7 +28,7 @@
+ #define CONFIG_MEMORYSTATUS 1 // <rdar://problem/13604997>
+ #include <sys/types.h> /* for user_size_t */
+ #include <spawn.h>
+-#include <spawn_private.h>
++#include "spawn_private.h"
+ #include <sys/spawn_internal.h>
+ #include <sys/process_policy.h>
+ #include <stdlib.h>
+diff --git a/libsyscall/xcodescripts/compile-syscalls.pl b/libsyscall/xcodescripts/compile-syscalls.pl
+index f0c2691..8eddf43 100755
+--- a/libsyscall/xcodescripts/compile-syscalls.pl
++++ b/libsyscall/xcodescripts/compile-syscalls.pl
+@@ -63,7 +63,7 @@ my @CFLAGS = (
+ 	"-x assembler-with-cpp",
+ 	"-c",
+ 	"-isysroot", $ENV{'SDKROOT'} || "/",
+-	"-I".$ENV{"SDKROOT"}."/System/Library/Frameworks/System.framework/PrivateHeaders",
++	"-I".$ENV{"DEPENDENCIES_DIR"}."/System/Library/Frameworks/System.framework/PrivateHeaders",
+ );
+ 
+ chomp(my $LIBTOOL = `xcrun -sdk "$ENV{'SDKROOT'}" -find libtool`);

--- a/patches/xnu-4903.221.2.libsyscall-build.p1.patch
+++ b/patches/xnu-4903.221.2.libsyscall-build.p1.patch
@@ -9,8 +9,8 @@ index 737c410..349ff77 100644
 -GCC_PREPROCESSOR_DEFINITIONS = CF_OPEN_SOURCE CF_EXCLUDE_CSTD_HEADERS DEBUG _FORTIFY_SOURCE=0
 -HEADER_SEARCH_PATHS = $(PROJECT_DIR)/mach $(PROJECT_DIR)/os $(PROJECT_DIR)/wrappers $(PROJECT_DIR)/wrappers/string $(PROJECT_DIR)/wrappers/libproc $(PROJECT_DIR)/wrappers/libproc/spawn $(BUILT_PRODUCTS_DIR)/internal_hdr/include $(BUILT_PRODUCTS_DIR)/mig_hdr/local/include $(BUILT_PRODUCTS_DIR)/mig_hdr/include $(SDKROOT)/System/Library/Frameworks/System.framework/PrivateHeaders
 +GCC_PREPROCESSOR_DEFINITIONS = CF_OPEN_SOURCE CF_EXCLUDE_CSTD_HEADERS DEBUG _FORTIFY_SOURCE=0 __PUREDARWIN__=1
-+HEADER_SEARCH_PATHS = $(PROJECT_DIR)/mach $(PROJECT_DIR)/os $(PROJECT_DIR)/wrappers $(PROJECT_DIR)/wrappers/string $(PROJECT_DIR)/wrappers/libproc $(PROJECT_DIR)/wrappers/libproc/spawn $(BUILT_PRODUCTS_DIR)/internal_hdr/include $(BUILT_PRODUCTS_DIR)/mig_hdr/local/include $(BUILT_PRODUCTS_DIR)/mig_hdr/include $(DEPENDENCIES_DIR)/System/Library/Frameworks/System.framework/PrivateHeaders
-+FRAMEWORK_SEARCH_PATHS = $(DEPENDENCIES_DIR)/System/Library/Frameworks
++HEADER_SEARCH_PATHS = $(PROJECT_DIR)/mach $(PROJECT_DIR)/os $(PROJECT_DIR)/wrappers $(PROJECT_DIR)/wrappers/string $(PROJECT_DIR)/wrappers/libproc $(PROJECT_DIR)/wrappers/libproc/spawn $(BUILT_PRODUCTS_DIR)/internal_hdr/include $(BUILT_PRODUCTS_DIR)/mig_hdr/local/include $(BUILT_PRODUCTS_DIR)/mig_hdr/include $(DEPROOT)/System/Library/Frameworks/System.framework/PrivateHeaders
++FRAMEWORK_SEARCH_PATHS = $(DEPROOT)/System/Library/Frameworks
  WARNING_CFLAGS = -Wmost
 -GCC_TREAT_WARNINGS_AS_ERRORS = YES
  GCC_WARN_ABOUT_MISSING_NEWLINE = YES
@@ -254,7 +254,7 @@ index f0c2691..8eddf43 100755
  	"-c",
  	"-isysroot", $ENV{'SDKROOT'} || "/",
 -	"-I".$ENV{"SDKROOT"}."/System/Library/Frameworks/System.framework/PrivateHeaders",
-+	"-I".$ENV{"DEPENDENCIES_DIR"}."/System/Library/Frameworks/System.framework/PrivateHeaders",
++	"-I".$ENV{"DEPROOT"}."/System/Library/Frameworks/System.framework/PrivateHeaders",
  );
  
  chomp(my $LIBTOOL = `xcrun -sdk "$ENV{'SDKROOT'}" -find libtool`);

--- a/patches/xnu-4903.221.2.xnu_dependencies_dir.p1.patch
+++ b/patches/xnu-4903.221.2.xnu_dependencies_dir.p1.patch
@@ -1,0 +1,17 @@
+diff --git a/makedefs/MakeInc.cmd b/makedefs/MakeInc.cmd
+index a70a2d8..6e668a5 100644
+--- a/makedefs/MakeInc.cmd
++++ b/makedefs/MakeInc.cmd
+@@ -103,10 +103,10 @@ ifeq ($(DSYMUTIL),)
+ 	export DSYMUTIL := $(shell $(XCRUN) -sdk $(SDKROOT) -find dsymutil)
+ endif
+ ifeq ($(CTFCONVERT),)
+-	export CTFCONVERT := $(shell $(XCRUN) -sdk $(SDKROOT) -find ctfconvert)
++	export CTFCONVERT := $(DEPENDENCIES_DIR)/usr/local/bin/ctfconvert
+ endif
+ ifeq ($(CTFMERGE),)
+-	export CTFMERGE :=  $(shell $(XCRUN) -sdk $(SDKROOT) -find ctfmerge)
++	export CTFMERGE :=  $(DEPENDENCIES_DIR)/usr/local/bin/ctfmerge
+ endif
+ ifeq ($(CTFINSERT),)
+ 	export CTFINSERT := $(shell $(XCRUN) -sdk $(SDKROOT) -find ctf_insert)

--- a/patches/xnu-4903.221.2.xnu_dependencies_dir.p1.patch
+++ b/patches/xnu-4903.221.2.xnu_dependencies_dir.p1.patch
@@ -7,11 +7,11 @@ index a70a2d8..6e668a5 100644
  endif
  ifeq ($(CTFCONVERT),)
 -	export CTFCONVERT := $(shell $(XCRUN) -sdk $(SDKROOT) -find ctfconvert)
-+	export CTFCONVERT := $(DEPENDENCIES_DIR)/usr/local/bin/ctfconvert
++	export CTFCONVERT := $(DEPROOT)/usr/local/bin/ctfconvert
  endif
  ifeq ($(CTFMERGE),)
 -	export CTFMERGE :=  $(shell $(XCRUN) -sdk $(SDKROOT) -find ctfmerge)
-+	export CTFMERGE :=  $(DEPENDENCIES_DIR)/usr/local/bin/ctfmerge
++	export CTFMERGE :=  $(DEPROOT)/usr/local/bin/ctfmerge
  endif
  ifeq ($(CTFINSERT),)
  	export CTFINSERT := $(shell $(XCRUN) -sdk $(SDKROOT) -find ctf_insert)

--- a/patches/xnu-4903.221.2.xnu_firehose_dir.p1.patch
+++ b/patches/xnu-4903.221.2.xnu_firehose_dir.p1.patch
@@ -1,0 +1,22 @@
+diff --git a/makedefs/MakeInc.def b/makedefs/MakeInc.def
+index 73f7cdc..36b90c1 100644
+--- a/makedefs/MakeInc.def
++++ b/makedefs/MakeInc.def
+@@ -422,7 +422,7 @@ LDFLAGS_KERNEL_GEN = \
+ 	-Wl,-headerpad,152
+ 
+ # LDFLAGS_KERNEL_SDK	= -L$(SDKROOT)/usr/local/lib/kernel -lfirehose_kernel
+-LDFLAGS_KERNEL_SDK	= -L$(SDKROOT)/usr/local/lib/kernel
++LDFLAGS_KERNEL_SDK	= -L$(DEPENDENCIES_DIR)/usr/local/lib/kernel
+ 
+ LDFLAGS_KERNEL_RELEASE	=
+ LDFLAGS_KERNEL_DEVELOPMENT     =
+@@ -632,7 +632,7 @@ INCFLAGS_IMPORT	= $(patsubst %, -I$(OBJROOT)/EXPORT_HDRS/%, $(COMPONENT_IMPORT_L
+ INCFLAGS_EXTERN	= -I$(SRCROOT)/EXTERNAL_HEADERS
+ INCFLAGS_GEN	= -I$(SRCROOT)/$(COMPONENT) -I$(OBJROOT)/EXPORT_HDRS/$(COMPONENT)
+ INCFLAGS_LOCAL	= -I.
+-INCFLAGS_SDK	= -I$(SDKROOT)/usr/local/include/kernel
++INCFLAGS_SDK	= -I$(DEPENDENCIES_DIR)/usr/local/include/kernel
+ 
+ INCFLAGS	= $(INCFLAGS_LOCAL) $(INCFLAGS_GEN) $(INCFLAGS_IMPORT) $(INCFLAGS_EXTERN) $(INCFLAGS_MAKEFILE) $(INCFLAGS_SDK)
+ 

--- a/patches/xnu-4903.221.2.xnu_firehose_dir.p1.patch
+++ b/patches/xnu-4903.221.2.xnu_firehose_dir.p1.patch
@@ -7,7 +7,7 @@ index 73f7cdc..36b90c1 100644
  
  # LDFLAGS_KERNEL_SDK	= -L$(SDKROOT)/usr/local/lib/kernel -lfirehose_kernel
 -LDFLAGS_KERNEL_SDK	= -L$(SDKROOT)/usr/local/lib/kernel
-+LDFLAGS_KERNEL_SDK	= -L$(DEPENDENCIES_DIR)/usr/local/lib/kernel
++LDFLAGS_KERNEL_SDK	= -L$(DEPROOT)/usr/local/lib/kernel
  
  LDFLAGS_KERNEL_RELEASE	=
  LDFLAGS_KERNEL_DEVELOPMENT     =
@@ -16,7 +16,7 @@ index 73f7cdc..36b90c1 100644
  INCFLAGS_GEN	= -I$(SRCROOT)/$(COMPONENT) -I$(OBJROOT)/EXPORT_HDRS/$(COMPONENT)
  INCFLAGS_LOCAL	= -I.
 -INCFLAGS_SDK	= -I$(SDKROOT)/usr/local/include/kernel
-+INCFLAGS_SDK	= -I$(DEPENDENCIES_DIR)/usr/local/include/kernel
++INCFLAGS_SDK	= -I$(DEPROOT)/usr/local/include/kernel
  
  INCFLAGS	= $(INCFLAGS_LOCAL) $(INCFLAGS_GEN) $(INCFLAGS_IMPORT) $(INCFLAGS_EXTERN) $(INCFLAGS_MAKEFILE) $(INCFLAGS_SDK)
  

--- a/plists/PD18_0.plist
+++ b/plists/PD18_0.plist
@@ -51,7 +51,7 @@
 			<key>version</key>
 			<string>11.1</string>
 			<key>github</key>
-			<string>PureDarwin/Libsystem</string>
+			<string>PureDarwin/AppleI386GenericPlatform</string>
 			<key>dependencies</key>
 			<dict>
 				<key>header</key>

--- a/plists/PD18_0.plist
+++ b/plists/PD18_0.plist
@@ -215,6 +215,11 @@
 		<dict>
 			<key>version</key>
 			<string>4903.221.2</string>
+			<key>environment</key>
+			<dict>
+				<key>KERNEL_CONFIGS</key>
+				<string>RELEASE</string>
+			</dict>
 			<key>dependencies</key>
 			<dict>
 				<key>build</key>
@@ -245,6 +250,11 @@
 			<string>xnu</string>
 			<key>version</key>
 			<string>4903.221.2</string>
+			<key>environment</key>
+			<dict>
+				<key>KERNEL_CONFIGS</key>
+				<string>RELEASE</string>
+			</dict>
 			<key>dependencies</key>
 			<dict>
 				<key>header</key>

--- a/plists/PD18_0.plist
+++ b/plists/PD18_0.plist
@@ -61,6 +61,12 @@
 			</dict>
 		</dict>
 
+		<key>AvailabilityVersions</key>
+		<dict>
+			<key>version</key>
+			<string>33.200.4</string>
+		</dict>
+
 		<key>Libsyscall</key>
 		<dict>
 			<key>original</key>
@@ -70,6 +76,7 @@
 			<key>patchfiles</key>
 			<array>
 				<string>xnu-4903.221.2.bsd-xcconfig.p1.patch</string>
+				<string>xnu-4903.221.2.libsyscall-build.p1.patch</string>
 			</array>
 		</dict>
 
@@ -97,13 +104,13 @@
 		</dict>
 
 		<key>dtrace</key>
-		<array>
+		<dict>
 			<key>version</key>
 			<string>284.200.15</string>
-		</array>
+		</dict>
 
 		<key>dtrace_host</key>
-		<array>
+		<dict>
 			<key>original</key>
 			<string>dtrace</string>
 			<key>version</key>
@@ -112,9 +119,9 @@
 			<string>dtrace_host</string>
 			<key>patchfiles</key>
 			<array>
-				<string>dtrace-284.400.15.host-tools.p1.patch</string>
+				<string>dtrace-284.200.15.host-tools.p1.patch</string>
 			</array>
-		</array>
+		</dict>
 
 		<key>libcoreservices</key>
 		<dict>
@@ -142,6 +149,7 @@
 			<dict>
 				<key>header</key>
 				<array>
+					<string>libplatform_xnu_headers</string>
 					<string>xnu_headers</string>
 				</array>
 			</dict>
@@ -155,9 +163,7 @@
 		<key>libplatform</key>
 		<dict>
 			<key>version</key>
-			<string>161.1</string>
-			<key>github</key>
-			<string>PureDarwin/libplatform</string>
+			<string>177.200.16</string>
 			<key>dependencies</key>
 			<dict>
 				<key>header</key>
@@ -165,6 +171,18 @@
 					<string>xnubuild</string>
 				</array>
 			</dict>
+		</dict>
+
+		<key>libplatform_xnu_headers</key>
+		<dict>
+			<key>original</key>
+			<string>libplatform</string>
+			<key>version</key>
+			<string>177.200.16</string>
+			<key>patchfiles</key>
+			<array>
+				<string>libplatform-177-20.16.xnu-headers.p1.patch</string>
+			</array>
 		</dict>
 
 		<key>libpthread</key>
@@ -215,6 +233,8 @@
 				<string>xnu-4903.221.2.fix_codesigning.p1.patch</string>
 				<string>xnu-4903.221.2.fix_system_framework.p1.patch</string>
 				<string>xnu-4903.221.2.xnu_dependencies_dir.p1.patch</string>
+				<string>xnu-4903.221.2.kext_copyright_check.p1.patch</string>
+				<string>xnu-4903.221.2.xnu_firehose_dir.p1.patch</string>
 			</array>
 		</dict>
 
@@ -224,6 +244,13 @@
 			<string>xnu</string>
 			<key>version</key>
 			<string>4903.221.2</string>
+			<key>dependencies</key>
+			<dict>
+				<key>header</key>
+				<array>
+					<string>AvailabilityVersions</string>
+				</array>
+			</dict>
 			<key>patchfiles</key>
 			<array>
 				<string>xnu-4903.221.2.availability_versions.p1.patch</string>

--- a/plists/PD18_0.plist
+++ b/plists/PD18_0.plist
@@ -270,14 +270,6 @@
 				<string>xnu-4903.221.2.xnu_dependencies_dir.p1.patch</string>
 			</array>
 		</dict>
-
-		<key>xnubuild</key>
-		<dict>
-			<key>version</key>
-			<string>10.14.1.1</string>
-			<key>github</key>
-			<string>PureDarwin/xnubuild</string>
-		</dict>
 	</dict>
 </dict>
 </plist>

--- a/plists/PD18_0.plist
+++ b/plists/PD18_0.plist
@@ -83,7 +83,7 @@
 		<key>Libsystem</key>
 		<dict>
 			<key>version</key>
-			<string>10.1</string>
+			<string>11</string>
 			<key>github</key>
 			<string>PureDarwin/Libsystem</string>
 		</dict>

--- a/plists/PD18_0.plist
+++ b/plists/PD18_0.plist
@@ -149,7 +149,7 @@
 			<dict>
 				<key>header</key>
 				<array>
-					<string>libplatform_xnu_headers</string>
+					<string>libplatform_headers</string>
 					<string>xnu_headers</string>
 				</array>
 			</dict>
@@ -174,7 +174,7 @@
 			</dict>
 		</dict>
 
-		<key>libplatform_xnu_headers</key>
+		<key>libplatform_headers</key>
 		<dict>
 			<key>original</key>
 			<string>libplatform</string>
@@ -197,7 +197,7 @@
 				<key>header</key>
 				<array>
 					<string>Libsystem</string>
-					<string>libplatform</string>
+					<string>libplatform_headers</string>
 					<string>xnu_headers</string>
 				</array>
 			</dict>

--- a/plists/PD18_0.plist
+++ b/plists/PD18_0.plist
@@ -1,0 +1,245 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>source_sites</key>
+	<array>
+		<string>https://opensource.apple.com/tarballs</string>
+	</array>
+
+	<key>patch_sites</key>
+	<array>
+		<string>https://github.com/PureDarwin/PureDarwin/raw/PD18.0/patches</string>
+	</array>
+
+	<key>build</key>
+	<string>PD18_0</string>
+	<key>darwin</key>
+	<string>Darwin 18.0</string>
+	<key>macosx</key>
+	<string>macOS 10.14</string>
+
+	<key>environment</key>
+	<dict>
+		<key>INSTALLED_PRODUCT_ASIDES</key>
+		<string>YES</string>
+		<key>MACOSX_DEPLOYMENT_TARGET</key>
+		<string>10.14</string>
+		<key>UNAME_RELEASE</key>
+		<string>17.4</string>
+		<key>UNAME_SYSNAME</key>
+		<string>Darwin</string>
+		<key>RC_TARGET_CONFIG</key>
+		<string>MacOSX</string>
+		<key>SDKROOT</key>
+		<string>macosx</string>
+	</dict>
+
+	<key>groups</key>
+	<dict>
+		<key>boot</key>
+		<array>
+			<string>xnu AppleI386GenericPlatform corecrypto</string>
+			<string>libpthread libcoreservices</string>
+		</array>
+	</dict>
+
+	<key>projects</key>
+	<dict>
+		<key>AppleI386GenericPlatform</key>
+		<dict>
+			<key>version</key>
+			<string>11.1</string>
+			<key>github</key>
+			<string>PureDarwin/Libsystem</string>
+			<key>dependencies</key>
+			<dict>
+				<key>header</key>
+				<array>
+					<string>xnubuild</string>
+				</array>
+			</dict>
+		</dict>
+
+		<key>Libsyscall</key>
+		<dict>
+			<key>original</key>
+			<string>xnu</string>
+			<key>version</key>
+			<string>4093.221.2</string>
+			<key>patchfiles</key>
+			<array>
+				<string>xnu-4903.221.2.bsd-xcconfig.p1.patch</string>
+			</array>
+		</dict>
+
+		<key>Libsystem</key>
+		<dict>
+			<key>version</key>
+			<string>10.1</string>
+			<key>github</key>
+			<string>PureDarwin/Libsystem</string>
+		</dict>
+
+		<key>corecrypto</key>
+		<dict>
+			<key>version</key>
+			<string>2000.1</string>
+			<key>github</key>
+			<string>PureDarwin/corecrypto</string>
+			<key>dependencies</key>
+			<dict>
+				<key>header</key>
+				<array>
+					<string>xnubuild</string>
+				</array>
+			</dict>
+		</dict>
+
+		<key>dtrace</key>
+		<array>
+			<key>version</key>
+			<string>284.200.15</string>
+		</array>
+
+		<key>dtrace_host</key>
+		<array>
+			<key>original</key>
+			<string>dtrace</string>
+			<key>version</key>
+			<string>284.200.15</string>
+			<key>target</key>
+			<string>dtrace_host</string>
+			<key>patchfiles</key>
+			<array>
+				<string>dtrace-284.400.15.host-tools.p1.patch</string>
+			</array>
+		</array>
+
+		<key>libcoreservices</key>
+		<dict>
+			<key>version</key>
+			<string>10.1</string>
+			<key>github</key>
+			<string>PureDarwin/libcoreservices</string>
+		</dict>
+
+		<key>libdispatch</key>
+		<dict>
+			<key>version</key>
+			<string>1008.220.2</string>
+		</dict>
+
+		<key>libfirehose_kernel</key>
+		<dict>
+			<key>original</key>
+			<string>libdispatch</string>
+			<key>version</key>
+			<string>1008.220.2</string>
+			<key>target</key>
+			<string>libfirehose_kernel</string>
+			<key>dependencies</key>
+			<dict>
+				<key>header</key>
+				<array>
+					<string>xnu_headers</string>
+				</array>
+			</dict>
+			<key>patchfiles</key>
+			<array>
+				<string>libdispatch-1008.220.2.header-paths.p1.patch</string>
+				<string>libdispatch-1008.220.2.fix-build.p1.patch</string>
+			</array>
+		</dict>
+
+		<key>libplatform</key>
+		<dict>
+			<key>version</key>
+			<string>161.1</string>
+			<key>github</key>
+			<string>PureDarwin/libplatform</string>
+			<key>dependencies</key>
+			<dict>
+				<key>header</key>
+				<array>
+					<string>xnubuild</string>
+				</array>
+			</dict>
+		</dict>
+
+		<key>libpthread</key>
+		<dict>
+			<key>version</key>
+			<string>10</string>
+			<key>github</key>
+			<string>PureDarwin/libpthread</string>
+			<key>dependencies</key>
+			<dict>
+				<key>header</key>
+				<array>
+					<string>Libsystem</string>
+					<string>libplatform</string>
+					<string>xnubuild</string>
+				</array>
+			</dict>
+		</dict>
+
+		<key>libxpc</key>
+		<dict>
+			<key>version</key>
+			<string>10.2</string>
+			<key>github</key>
+			<string>PureDarwin/XPC</string>
+		</dict>
+
+		<key>xnu</key>
+		<dict>
+			<key>version</key>
+			<string>4903.221.2</string>
+			<key>dependencies</key>
+			<dict>
+				<key>build</key>
+				<array>
+					<string>AvailabilityVersions</string>
+					<string>dtrace_host</string>
+					<string>libfirehose_kernel</string>
+				</array>
+				<key>header</key>
+				<array>
+					<string>AvailabilityVersions</string>
+				</array>
+			</dict>
+			<key>patchfiles</key>
+			<array>
+				<string>xnu-4903.221.2.availability_versions.p1.patch</string>
+				<string>xnu-4903.221.2.fix_codesigning.p1.patch</string>
+				<string>xnu-4903.221.2.fix_system_framework.p1.patch</string>
+				<string>xnu-4903.221.2.xnu_dependencies_dir.p1.patch</string>
+			</array>
+		</dict>
+
+		<key>xnu_headers</key>
+		<dict>
+			<key>original</key>
+			<string>xnu</string>
+			<key>version</key>
+			<string>4903.221.2</string>
+			<key>patchfiles</key>
+			<array>
+				<string>xnu-4903.221.2.availability_versions.p1.patch</string>
+				<string>xnu-4903.221.2.fix_codesigning.p1.patch</string>
+				<string>xnu-4903.221.2.fix_system_framework.p1.patch</string>
+				<string>xnu-4903.221.2.xnu_dependencies_dir.p1.patch</string>
+			</array>
+		</dict>
+
+		<key>xnubuild</key>
+		<dict>
+			<key>version</key>
+			<string>10.14.1.1</string>
+			<key>github</key>
+			<string>PureDarwin/xnubuild</string>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/plists/PD18_0.plist
+++ b/plists/PD18_0.plist
@@ -56,7 +56,7 @@
 			<dict>
 				<key>header</key>
 				<array>
-					<string>xnubuild</string>
+					<string>xnu_headers</string>
 				</array>
 			</dict>
 		</dict>
@@ -98,7 +98,7 @@
 			<dict>
 				<key>header</key>
 				<array>
-					<string>xnubuild</string>
+					<string>xnu_headers</string>
 				</array>
 			</dict>
 		</dict>
@@ -169,7 +169,7 @@
 			<dict>
 				<key>header</key>
 				<array>
-					<string>xnubuild</string>
+					<string>xnu_headers</string>
 				</array>
 			</dict>
 		</dict>
@@ -198,7 +198,7 @@
 				<array>
 					<string>Libsystem</string>
 					<string>libplatform</string>
-					<string>xnubuild</string>
+					<string>xnu_headers</string>
 				</array>
 			</dict>
 		</dict>

--- a/plists/PD18_0.plist
+++ b/plists/PD18_0.plist
@@ -157,6 +157,7 @@
 			<array>
 				<string>libdispatch-1008.220.2.header-paths.p1.patch</string>
 				<string>libdispatch-1008.220.2.fix-build.p1.patch</string>
+				<string>libdispatch-1008.220.2-xcodeconfig_BSD.xcconfig.add</string>
 			</array>
 		</dict>
 

--- a/plists/PD18_2.plist
+++ b/plists/PD18_2.plist
@@ -13,11 +13,11 @@
 	</array>
 
 	<key>build</key>
-	<string>PD18_0</string>
+	<string>PD18_2</string>
 	<key>darwin</key>
-	<string>Darwin 18.0</string>
+	<string>Darwin 18.2</string>
 	<key>macosx</key>
-	<string>macOS 10.14</string>
+	<string>macOS 10.14.2</string>
 
 	<key>environment</key>
 	<dict>

--- a/plists/PD18_2.plist
+++ b/plists/PD18_2.plist
@@ -17,7 +17,7 @@
 	<key>darwin</key>
 	<string>Darwin 18.2</string>
 	<key>macosx</key>
-	<string>macOS 10.14.2</string>
+	<string>macOS 10.14.1</string>
 
 	<key>environment</key>
 	<dict>
@@ -26,7 +26,7 @@
 		<key>MACOSX_DEPLOYMENT_TARGET</key>
 		<string>10.14</string>
 		<key>UNAME_RELEASE</key>
-		<string>17.4</string>
+		<string>18.2</string>
 		<key>UNAME_SYSNAME</key>
 		<string>Darwin</string>
 		<key>RC_TARGET_CONFIG</key>


### PR DESCRIPTION
This PR adds in a darwinbuild plist that builds the Mojave sources from Apple, as well as all required patches to accomplish same. I have tested this, and the `xnu` project and all its dependencies correctly build.