### PR TITLE
Change PD18_2 darwinbuild plist to use xnubuild

### DIFF
--- a/plists/PD18_2.plist
+++ b/plists/PD18_2.plist
@@ -39,7 +39,7 @@
 	<dict>
 		<key>boot</key>
 		<array>
-			<string>xnu AppleI386GenericPlatform corecrypto</string>
+			<string>xnubuild AppleI386GenericPlatform corecrypto</string>
 			<string>libpthread libcoreservices</string>
 		</array>
 	</dict>
@@ -56,11 +56,7 @@
 			<dict>
 				<key>build</key>
 				<array>
-					<string>libkmod</string>
-				</array>
-				<key>header</key>
-				<array>
-					<string>xnu_headers</string>
+					<string>xnubuild</string>
 				</array>
 			</dict>
 		</dict>
@@ -84,22 +80,9 @@
 		<key>Libsyscall</key>
 		<dict>
 			<key>original</key>
-			<string>xnu</string>
+			<string>xnubuild</string>
 			<key>version</key>
-			<string>4903.221.2</string>
-			<key>dependencies</key>
-			<dict>
-				<key>header</key>
-				<array>
-					<string>xnu_headers</string>
-				</array>
-			</dict>
-			<key>patchfiles</key>
-			<array>
-				<string>xnu-4903.221.2.bsd-xcconfig.p1.patch</string>
-				<string>xnu-4903.221.2.libsyscall-build.p1.patch</string>
-				<string>xnu-4903.221.2.libsyscall-mig-flags.p1.patch</string>
-			</array>
+			<string>10.14.3.1</string>
 		</dict>
 
 		<key>Libsystem</key>
@@ -125,7 +108,7 @@
 				<key>header</key>
 				<array>
 					<string>libdispatch</string>
-					<string>xnu_headers</string>
+					<string>xnubuild</string>
 				</array>
 			</dict>
 		</dict>
@@ -148,7 +131,7 @@
 			<dict>
 				<key>header</key>
 				<array>
-					<string>xnu_headers</string>
+					<string>xnubuild</string>
 				</array>
 			</dict>
 		</dict>
@@ -196,7 +179,7 @@
 					<string>Libsyscall</string>
 					<string>libplatform_headers</string>
 					<string>libpthread</string>
-					<string>xnu_headers</string>
+					<string>xnubuild</string>
 				</array>
 			</dict>
 		</dict>
@@ -216,7 +199,7 @@
 				<key>header</key>
 				<array>
 					<string>libplatform_headers</string>
-					<string>xnu_headers</string>
+					<string>xnubuild</string>
 				</array>
 			</dict>
 		</dict>
@@ -245,7 +228,7 @@
 				<array>
 					<string>Libsyscall</string>
 					<string>libpthread</string>
-					<string>xnu_headers</string>
+					<string>xnubuild</string>
 				</array>
 			</dict>
 		</dict>
@@ -273,7 +256,7 @@
 					<string>Libsyscall</string>
 					<string>Libsystem</string>
 					<string>libplatform_headers</string>
-					<string>xnu_headers</string>
+					<string>xnubuild</string>
 				</array>
 			</dict>
 		</dict>
@@ -295,7 +278,7 @@
 					<string>Libsyscall</string>
 					<string>Libsystem</string>
 					<string>libplatform_headers</string>
-					<string>xnu_headers</string>
+					<string>xnubuild</string>
 				</array>
 			</dict>
 		</dict>
@@ -317,7 +300,7 @@
 					<string>Libsyscall</string>
 					<string>Libsystem</string>
 					<string>libplatform_headers</string>
-					<string>xnu_headers</string>
+					<string>xnubuild</string>
 				</array>
 			</dict>
 		</dict>
@@ -396,67 +379,12 @@
 			</array>
 		</dict>
 
-		<key>xnu</key>
+		<key>xnubuild</key>
 		<dict>
 			<key>version</key>
-			<string>4903.221.2</string>
-			<key>environment</key>
-			<dict>
-				<key>KERNEL_CONFIGS</key>
-				<string>RELEASE</string>
-				<key>BUILD_WERROR</key>
-				<string>0</string>
-			</dict>
-			<key>dependencies</key>
-			<dict>
-				<key>build</key>
-				<array>
-					<string>AvailabilityVersions</string>
-					<string>dtrace_host</string>
-					<string>libfirehose_kernel</string>
-				</array>
-				<key>header</key>
-				<array>
-					<string>AvailabilityVersions</string>
-				</array>
-			</dict>
-			<key>patchfiles</key>
-			<array>
-				<string>xnu-4903.221.2.availability_versions.p1.patch</string>
-				<string>xnu-4903.221.2.fix_codesigning.p1.patch</string>
-				<string>xnu-4903.221.2.fix_system_framework.p1.patch</string>
-				<string>xnu-4903.221.2.xnu_dependencies_dir.p1.patch</string>
-				<string>xnu-4903.221.2.kext_copyright_check.p1.patch</string>
-				<string>xnu-4903.221.2.xnu_firehose_dir.p1.patch</string>
-				<string>xnu-4903.221.2.fix_weird_mig_error.p1.patch</string>
-			</array>
-		</dict>
-
-		<key>xnu_headers</key>
-		<dict>
-			<key>original</key>
-			<string>xnu</string>
-			<key>version</key>
-			<string>4903.221.2</string>
-			<key>environment</key>
-			<dict>
-				<key>KERNEL_CONFIGS</key>
-				<string>RELEASE</string>
-			</dict>
-			<key>dependencies</key>
-			<dict>
-				<key>header</key>
-				<array>
-					<string>AvailabilityVersions</string>
-				</array>
-			</dict>
-			<key>patchfiles</key>
-			<array>
-				<string>xnu-4903.221.2.availability_versions.p1.patch</string>
-				<string>xnu-4903.221.2.fix_codesigning.p1.patch</string>
-				<string>xnu-4903.221.2.fix_system_framework.p1.patch</string>
-				<string>xnu-4903.221.2.xnu_dependencies_dir.p1.patch</string>
-			</array>
+			<string>10.14.3.1</string>
+			<key>github</key>
+			<string>PureDarwin/xnubuild</string>
 		</dict>
 	</dict>
 </dict>


### PR DESCRIPTION
This helps ensure that there is only one source of truth for patching and building XNU. Previously,
we had to keep this plist and the xnubuild repo synchronized.