### PR TITLE
Add IOACPIFamily to darwinbuild plist

### DIFF
--- a/plists/PD18_2.plist
+++ b/plists/PD18_2.plist
@@ -84,7 +84,7 @@
 		<key>IOACPIFamily</key>
 		<dict>
 			<key>version</key>
-			<string>100</string>
+			<string>100.0.1</string>
 		</dict>
 
 		<key>Libsyscall</key>

--- a/plists/PD18_2.plist
+++ b/plists/PD18_2.plist
@@ -39,7 +39,7 @@
 	<dict>
 		<key>boot</key>
 		<array>
-			<string>xnu AppleI386GenericPlatform corecrypto</string>
+			<string>xnu AppleI386GenericPlatform IOACPIFamily corecrypto</string>
 			<string>libpthread libcoreservices</string>
 		</array>
 	</dict>
@@ -79,6 +79,12 @@
 			<string>10.2</string>
 			<key>target</key>
 			<string>CrashReporterClient</string>
+		</dict>
+
+		<key>IOACPIFamily</key>
+		<dict>
+			<key>version</key>
+			<string>100</string>
 		</dict>
 
 		<key>Libsyscall</key>

--- a/plists/PD18_2.plist
+++ b/plists/PD18_2.plist
@@ -85,6 +85,13 @@
 		<dict>
 			<key>version</key>
 			<string>100.0.1</string>
+			<key>dependencies</key>
+			<dict>
+				<key>header</key>
+				<array>
+					<string>xnu_headers</string>
+				</array>
+			</dict>
 		</dict>
 
 		<key>Libsyscall</key>

--- a/plists/PD18_2.plist
+++ b/plists/PD18_2.plist
@@ -85,6 +85,8 @@
 		<dict>
 			<key>version</key>
 			<string>100.0.1</string>
+			<key>github</key>
+			<string>PureDarwin/IOACPIFamily</string>
 			<key>dependencies</key>
 			<dict>
 				<key>header</key>


### PR DESCRIPTION
I have decided to resume work with an empty PureDarwin image (instead of the release image I've been using previously), so I'll be adding many low-level dependencies to this plist as I gradually build my way back up to launchd from scratch.