### PR TITLE
Add initial GitHub Actions support

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -1,0 +1,22 @@
+name: Build Pull Request
+
+on:
+  pull_request:
+    branches: [master]
+
+jobs:
+  build:
+    runs-on: macos-latest
+
+    steps:
+      - name: Clone
+        uses: actions/checkout@v2
+      - name: Install Packages
+        run: |
+          export HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1
+          brew install openssl ninja
+      - name: Build
+        run: |
+          mkdir build && cd build
+          cmake -G Ninja -DKERNEL_BUILD_XNU=1 -DOPENSSL_ROOT_DIR=/usr/local/opt/openssl ..
+          ninja

--- a/projects/Libraries/libSystem/libdispatch/src/firehose/CMakeLists.txt
+++ b/projects/Libraries/libSystem/libdispatch/src/firehose/CMakeLists.txt
@@ -7,7 +7,7 @@ target_include_directories(libfirehose_kernel PUBLIC include)
 target_compile_definitions(libfirehose_kernel PRIVATE
     KERNEL=1 DISPATCH_USE_DTRACE=0 OS_ATOMIC_CONFIG_MEMORY_ORDER_DEPENDENCY=1
     OS_ATOMIC_CONFIG_MEMORY_ORDER_DEPENDENCY=1 OS_ATOMIC_CONFIG_STARVATION_FREE_ONLY=0)
-target_compile_options(libfirehose_kernel PRIVATE -mkernel -Wno-packed -Wno-error=implicit-function-declaration)
+target_compile_options(libfirehose_kernel PRIVATE -mkernel -Wno-packed -Wno-error=implicit-function-declaration -Wno-implicit-function-declaration)
 target_link_libraries(libfirehose_kernel PRIVATE AvailabilityHeaders xnu_private_headers)
 target_link_libraries(libfirehose_kernel PRIVATE xnu_kernel_headers xnu_kernel_private_headers)
 target_link_libraries(libfirehose_kernel PRIVATE libplatform_headers libplatform_private_headers)

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -1,6 +1,3 @@
-set(PUREDARWIN_TOOLS_DIR ${CMAKE_CURRENT_BINARY_DIR}/prefix)
-file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/prefix)
-
 add_subdirectory(cctools)
 add_subdirectory(dtrace_ctf)
 add_subdirectory(mig)

--- a/tools/xar/CMakeLists.txt
+++ b/tools/xar/CMakeLists.txt
@@ -28,7 +28,7 @@ target_sources(host_libxar PRIVATE
     lib/zxar.c
 )
 target_include_directories(host_libxar PUBLIC include)
-target_include_directories(host_libxar PRIVATE ${OPENSSL_INCLUDE_DIR})
+target_include_directories(host_libxar PRIVATE ${OPENSSL_INCLUDE_DIR} ${LIBXML2_INCLUDE_DIR})
 target_link_libraries(host_libxar PRIVATE ZLIB::ZLIB LibXml2::LibXml2)
 
 add_executable(host_xar)

--- a/tools/xar/CMakeLists.txt
+++ b/tools/xar/CMakeLists.txt
@@ -29,7 +29,7 @@ target_sources(host_libxar PRIVATE
 )
 target_include_directories(host_libxar PUBLIC include)
 target_include_directories(host_libxar PRIVATE ${OPENSSL_INCLUDE_DIR})
-target_link_libraries(host_libxar PRIVATE -lz -lxml2)
+target_link_libraries(host_libxar PRIVATE ZLIB::ZLIB LibXml2::LibXml2)
 
 add_executable(host_xar)
 target_sources(host_xar PRIVATE


### PR DESCRIPTION
This PR adds a workflow that builds PureDarwin on the macOS platform. No runnable artifacts are created or uploaded since we don’t support that quite yet.