### PR TITLE
Fixing issues with setup.sh

### DIFF
--- a/tools/rc/README.md
+++ b/tools/rc/README.md
@@ -7,8 +7,8 @@ essentially a simpler version of darwinbuild that uses modern concepts
 and best practices.
 
 Currently, this project contains two scripts: `setup.sh` and `rc`, both written
-as standard UNIX shell scripts. The `setup.sh` scripts is meant to be executed
-in the user's shell (usually with the `source` builtin), and has been tested in
+as standard UNIX shell scripts. The `setup.sh` script is meant to be executed
+in the root of the PureDarwin folder (usually with the `source` builtin), and has been tested in
 both bash and zsh. The `setup.sh` script sets up the user's build environment
 for building PureDarwin, and installs the `rc` script into the user's PATH
 (which is updated to include the `${RC_HOST_BIN}` directory).

--- a/tools/rc/setup.sh
+++ b/tools/rc/setup.sh
@@ -26,7 +26,7 @@ case ${RC_HOST_TYPE} in
     "Darwin")
         if [ -n "${RC_DARWIN_ROOT}" ]; then
             # Darwin doesn't have readlink -f
-            export RC_DARWIN_ROOT="$(cd ${RC_DARWIN_ROOT} && pwd -P))"
+            export RC_DARWIN_ROOT="$(cd ${RC_DARWIN_ROOT} && pwd -P)"
         fi
 
         if [ -z "${RC_BUILD_JOBS}" ]; then

--- a/tools/rc/setup.sh
+++ b/tools/rc/setup.sh
@@ -18,7 +18,7 @@ if [ -z "${RC_HOST_TYPE}" ]; then
 fi
 
 if [ -z "${RC_DARWIN_ROOT}" ]; then
-    export RC_DARWIN_ROOT=$(cd `dirname $0` && cd ../.. && pwd)
+    export RC_DARWIN_ROOT=$(pwd -P)
 fi
 
 # Setup host-dependent variables/perform host-dependent checks
@@ -26,7 +26,7 @@ case ${RC_HOST_TYPE} in
     "Darwin")
         if [ -n "${RC_DARWIN_ROOT}" ]; then
             # Darwin doesn't have readlink -f
-            export RC_DARWIN_ROOT="$(cd ${RC_DARWIN_ROOT} && pwd -P)"
+            export RC_DARWIN_ROOT="$(cd ${RC_DARWIN_ROOT} && pwd -P))"
         fi
 
         if [ -z "${RC_BUILD_JOBS}" ]; then
@@ -36,12 +36,12 @@ case ${RC_HOST_TYPE} in
         ;;
     "Linux")
         if [ -n "${RC_DARWIN_ROOT}" ]; then
-            export RC_DARWIN_ROOT="$(cd ${RC_DARWIN_ROOT} && readlink -f ${PWD})"
+            export RC_DARWIN_ROOT="$(pwd -P)"
         fi
 
         if [ -z "${RC_BUILD_JOBS}" ]; then
             # TODO: Tune this
-            export RC_BUILD_JOBS=1
+            export RC_BUILD_JOBS=$(nproc --ignore=2)
         fi
 
         ;;


### PR DESCRIPTION
The setup.sh script on Linux is causing an issue where even if it is ran in the root of the project directory, it'll set all variables to `the` root of the machine. This, along with setting proper build jobs under Linux has been fixed.