### PR TITLE
Minor cleanup on the host tools build process

### DIFF
--- a/cmake/crosscompile.cmake
+++ b/cmake/crosscompile.cmake
@@ -2,9 +2,9 @@ function(add_darwin_executable name)
     cmake_parse_arguments(SL "NO_STANDARD_LIBRARIES;USE_HOST_SDK" "MACOSX_VERSION_MIN" "" ${ARGN})
 
     add_executable(${name})
-    add_dependencies(${name} darwin_ld)
+    add_dependencies(${name} host_ld)
     target_compile_definitions(${name} PRIVATE __PUREDARWIN__)
-    target_link_options(${name} PRIVATE -fuse-ld=$<TARGET_FILE:darwin_ld>)
+    target_link_options(${name} PRIVATE -fuse-ld=$<TARGET_FILE:host_ld>)
 
     if(NOT SL_USE_HOST_SDK)
         target_compile_options(${name} PRIVATE -nostdlib -nostdinc)
@@ -33,7 +33,7 @@ function(add_darwin_static_library name)
     cmake_parse_arguments(SL "USE_HOST_SDK" "MACOSX_VERSION_MIN" "" ${ARGN})
 
     add_library(${name} STATIC)
-    add_dependencies(${name} darwin_libtool)
+    add_dependencies(${name} host_libtool)
     target_compile_definitions(${name} PRIVATE __PUREDARWIN__)
 
     string(SUBSTRING ${name} 0 3 name_prefix)
@@ -64,8 +64,8 @@ function(add_darwin_shared_library name)
         add_library(${name} SHARED)
     endif()
 
-    add_dependencies(${name} darwin_ld)
-    target_link_options(${name} PRIVATE -fuse-ld=$<TARGET_FILE:darwin_ld>)
+    add_dependencies(${name} host_ld)
+    target_link_options(${name} PRIVATE -fuse-ld=$<TARGET_FILE:host_ld>)
     target_compile_definitions(${name} PRIVATE __PUREDARWIN__)
 
     string(SUBSTRING ${name} 0 3 name_prefix)

--- a/src/Kernel/xnu/CMakeLists.txt
+++ b/src/Kernel/xnu/CMakeLists.txt
@@ -10,8 +10,8 @@ externalproject_add(xnu_headers.extproj
             -D XNU_SRC=${CMAKE_CURRENT_SOURCE_DIR}
             -D XNU_OBJ=<BINARY_DIR>
             -D CODESIGN_ALLOCATE_PATH=$<TARGET_FILE:darwin_codesign_allocate>
-            -D CTFCONVERT_PATH=$<TARGET_FILE:ctfconvert.host>
-            -D CTFMERGE_PATH=$<TARGET_FILE:ctfmerge.host>
+            -D CTFCONVERT_PATH=$<TARGET_FILE:host_ctfconvert>
+            -D CTFMERGE_PATH=$<TARGET_FILE:host_ctfmerge>
             -D CTFINSERT_PATH=$<TARGET_FILE:host_ctf_insert>
             -D AVAILABILITY_PL_PATH=$<TARGET_FILE:availability.pl>
             -D MIG_PATH=${PUREDARWIN_SOURCE_DIR}/tools/mig/mig.sh
@@ -35,7 +35,7 @@ externalproject_add(xnu_headers.extproj
 )
 add_dependencies(xnu_headers.extproj darwin_codesign_allocate
     migcom host_strip host_lipo host_nm unifdef host_nmedit
-    ctfconvert.host ctfmerge.host availability.pl)
+    host_ctfconvert host_ctfmerge availability.pl)
 
 add_library(xnu_headers INTERFACE)
 add_dependencies(xnu_headers xnu_headers.extproj)
@@ -73,8 +73,8 @@ externalproject_add(xnu
             -D XNU_SRC=${CMAKE_CURRENT_SOURCE_DIR}
             -D XNU_OBJ=<BINARY_DIR>
             -D CODESIGN_ALLOCATE_PATH=$<TARGET_FILE:darwin_codesign_allocate>
-            -D CTFCONVERT_PATH=$<TARGET_FILE:ctfconvert.host>
-            -D CTFMERGE_PATH=$<TARGET_FILE:ctfmerge.host>
+            -D CTFCONVERT_PATH=$<TARGET_FILE:host_ctfconvert>
+            -D CTFMERGE_PATH=$<TARGET_FILE:host_ctfmerge>
             -D CTFINSERT_PATH=$<TARGET_FILE:host_ctf_insert>
             -D AVAILABILITY_PL_PATH=$<TARGET_FILE:availability.pl>
             -D LD_PATH=$<TARGET_FILE:darwin_ld>
@@ -100,7 +100,7 @@ externalproject_add(xnu
     USES_TERMINAL_CONFIGURE TRUE
     USES_TERMINAL_BUILD TRUE
 )
-add_dependencies(xnu xnu_headers libfirehose_kernel darwin_codesign_allocate ctfconvert.host ctfmerge.host migcom host_strip host_lipo host_nm unifdef host_nmedit availability.pl darwin_ld)
+add_dependencies(xnu xnu_headers libfirehose_kernel darwin_codesign_allocate host_ctfconvert host_ctfmerge migcom host_strip host_lipo host_nm unifdef host_nmedit availability.pl darwin_ld)
 
 install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/xnu/System/Library/Frameworks/Kernel.framework/Versions/A/Resources DESTINATION System/Library/Frameworks/Kernel.framework/Versions/A COMPONENT BaseSystem)
 install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/xnu/System/Library/Frameworks/Kernel.framework/Versions/A/Headers DESTINATION System/Library/Frameworks/Kernel.framework/Versions/A COMPONENT DeveloperTools)

--- a/src/Kernel/xnu/CMakeLists.txt
+++ b/src/Kernel/xnu/CMakeLists.txt
@@ -9,7 +9,7 @@ externalproject_add(xnu_headers.extproj
         cmake
             -D XNU_SRC=${CMAKE_CURRENT_SOURCE_DIR}
             -D XNU_OBJ=<BINARY_DIR>
-            -D CODESIGN_ALLOCATE_PATH=$<TARGET_FILE:darwin_codesign_allocate>
+            -D CODESIGN_ALLOCATE_PATH=$<TARGET_FILE:host_codesign_allocate>
             -D CTFCONVERT_PATH=$<TARGET_FILE:host_ctfconvert>
             -D CTFMERGE_PATH=$<TARGET_FILE:host_ctfmerge>
             -D CTFINSERT_PATH=$<TARGET_FILE:host_ctf_insert>
@@ -33,7 +33,7 @@ externalproject_add(xnu_headers.extproj
     USES_TERMINAL_CONFIGURE TRUE
     USES_TERMINAL_BUILD TRUE
 )
-add_dependencies(xnu_headers.extproj darwin_codesign_allocate
+add_dependencies(xnu_headers.extproj host_codesign_allocate
     migcom host_strip host_lipo host_nm unifdef host_nmedit
     host_ctfconvert host_ctfmerge availability.pl)
 
@@ -72,12 +72,12 @@ externalproject_add(xnu
         cmake
             -D XNU_SRC=${CMAKE_CURRENT_SOURCE_DIR}
             -D XNU_OBJ=<BINARY_DIR>
-            -D CODESIGN_ALLOCATE_PATH=$<TARGET_FILE:darwin_codesign_allocate>
+            -D CODESIGN_ALLOCATE_PATH=$<TARGET_FILE:host_codesign_allocate>
             -D CTFCONVERT_PATH=$<TARGET_FILE:host_ctfconvert>
             -D CTFMERGE_PATH=$<TARGET_FILE:host_ctfmerge>
             -D CTFINSERT_PATH=$<TARGET_FILE:host_ctf_insert>
             -D AVAILABILITY_PL_PATH=$<TARGET_FILE:availability.pl>
-            -D LD_PATH=$<TARGET_FILE:darwin_ld>
+            -D LD_PATH=$<TARGET_FILE:host_ld>
             -D MIG_PATH=${PUREDARWIN_SOURCE_DIR}/tools/mig/mig.sh
             -D MIGCOM_PATH=$<TARGET_FILE:migcom>
             -D STRIP_PATH=$<TARGET_FILE:host_strip>
@@ -100,7 +100,7 @@ externalproject_add(xnu
     USES_TERMINAL_CONFIGURE TRUE
     USES_TERMINAL_BUILD TRUE
 )
-add_dependencies(xnu xnu_headers libfirehose_kernel darwin_codesign_allocate host_ctfconvert host_ctfmerge migcom host_strip host_lipo host_nm unifdef host_nmedit availability.pl darwin_ld)
+add_dependencies(xnu xnu_headers libfirehose_kernel host_codesign_allocate host_ctfconvert host_ctfmerge migcom host_strip host_lipo host_nm unifdef host_nmedit availability.pl host_ld)
 
 install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/xnu/System/Library/Frameworks/Kernel.framework/Versions/A/Resources DESTINATION System/Library/Frameworks/Kernel.framework/Versions/A COMPONENT BaseSystem)
 install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/xnu/System/Library/Frameworks/Kernel.framework/Versions/A/Headers DESTINATION System/Library/Frameworks/Kernel.framework/Versions/A COMPONENT DeveloperTools)

--- a/tools/cctools/CMakeLists.txt
+++ b/tools/cctools/CMakeLists.txt
@@ -3,9 +3,3 @@ add_subdirectory(libstuff)
 add_subdirectory(misc)
 # add_subdirectory(otool) # disabled - doesn't build
 add_subdirectory(ld64/src)
-
-add_executable(darwin_ld ALIAS host_ld)
-add_executable(darwin_libtool ALIAS host_libtool)
-add_executable(darwin_codesign_allocate ALIAS host_codesign_allocate)
-add_executable(darwin_ctf_insert ALIAS host_ctf_insert)
-add_executable(darwin_install_name_tool ALIAS host_install_name_tool)

--- a/tools/cctools/ld64/src/3rd/CMakeLists.txt
+++ b/tools/cctools/ld64/src/3rd/CMakeLists.txt
@@ -9,10 +9,12 @@ target_sources(host_ld_helper PRIVATE
     mkpath_np.c
     find_executable.c
 )
+set_property(TARGET host_ld_helper PROPERTY OUTPUT_NAME ld_helper)
 target_include_directories(host_ld_helper PRIVATE include ../../../include ../../../include/foreign)
 target_compile_definitions(host_ld_helper PRIVATE -D__DARWIN_UNIX03)
 
 add_library(host_ld_BlocksRuntime STATIC)
+set_property(TARGET host_ld_BlocksRuntime PROPERTY OUTPUT_NAME ld_BlocksRuntime)
 target_sources(host_ld_BlocksRuntime PRIVATE
     BlocksRuntime/data.c
     BlocksRuntime/runtime.c

--- a/tools/cctools/ld64/src/ld/CMakeLists.txt
+++ b/tools/cctools/ld64/src/ld/CMakeLists.txt
@@ -23,6 +23,7 @@ target_link_libraries(host_ld PRIVATE
     host_libxar host_ld_helper host_ld_BlocksRuntime host_ld_libparsers host_ld_libpasses host_libstuff
     OpenSSL::SSL OpenSSL::Crypto
 )
+set_property(TARGET host_ld PROPERTY OUTPUT_NAME ld)
 set_property(TARGET host_ld PROPERTY CXX_STANDARD 11)
 target_include_directories(host_ld PRIVATE
     ../../../include

--- a/tools/cctools/libmacho/CMakeLists.txt
+++ b/tools/cctools/libmacho/CMakeLists.txt
@@ -2,4 +2,5 @@ add_library(host_libmacho STATIC)
 target_sources(host_libmacho PRIVATE
     arch.c
 )
+set_property(TARGET host_libmacho PROPERTY OUTPUT_NAME macho)
 target_include_directories(host_libmacho PRIVATE ../include ../include/foreign)

--- a/tools/cctools/libstuff/CMakeLists.txt
+++ b/tools/cctools/libstuff/CMakeLists.txt
@@ -44,6 +44,7 @@ target_sources(host_libstuff PRIVATE
     writeout.c
 )
 
+set_property(TARGET host_libstuff PROPERTY OUTPUT_NAME stuff)
 target_compile_definitions(host_libstuff PRIVATE
     __DARWIN_UNIX03
     PROGRAM_PREFIX=\"\"

--- a/tools/cctools/misc/CMakeLists.txt
+++ b/tools/cctools/misc/CMakeLists.txt
@@ -1,5 +1,6 @@
 macro(cctools_misc_executable name)
     add_executable(host_${name} ${name}.c)
+    set_property(TARGET host_${name} PROPERTY OUTPUT_NAME ${name})
     target_link_libraries(host_${name} PRIVATE host_libmacho host_libstuff)
     target_include_directories(host_${name} PRIVATE ../include ../include/foreign ../libstuff)
     target_compile_definitions(host_${name} PRIVATE -D__DARWIN_UNIX03)

--- a/tools/dtrace_ctf/tools/CMakeLists.txt
+++ b/tools/dtrace_ctf/tools/CMakeLists.txt
@@ -1,7 +1,7 @@
 find_package(ZLIB REQUIRED)
 
-add_executable(ctfconvert.host)
-target_sources(ctfconvert.host PRIVATE
+add_executable(host_ctfconvert)
+target_sources(host_ctfconvert PRIVATE
     alist.cpp
     array.c
     atom.cpp
@@ -26,12 +26,13 @@ target_sources(ctfconvert.host PRIVATE
     util.c
 )
 
-target_include_directories(ctfconvert.host PRIVATE ../include ../include/sys ../libelf)
-target_link_libraries(ctfconvert.host PRIVATE libelf.host libdwarf.host libctf.host ${ZLIB_LIBRARY_RELEASE})
-set_property(TARGET ctfconvert.host PROPERTY CXX_STANDARD 14)
+set_property(TARGET host_ctfconvert PROPERTY OUTPUT_NAME "ctfconvert")
+target_include_directories(host_ctfconvert PRIVATE ../include ../include/sys ../libelf)
+target_link_libraries(host_ctfconvert PRIVATE libelf.host libdwarf.host libctf.host ${ZLIB_LIBRARY_RELEASE})
+set_property(TARGET host_ctfconvert PROPERTY CXX_STANDARD 14)
 
-add_executable(ctfdump.host)
-target_sources(ctfdump.host PRIVATE
+add_executable(host_ctfdump)
+target_sources(host_ctfdump PRIVATE
     alist.cpp
     array.c
     atom.cpp
@@ -54,12 +55,13 @@ target_sources(ctfdump.host PRIVATE
     utils.c
 )
 
-target_include_directories(ctfdump.host PRIVATE ../include ../include/sys ../libelf)
-target_link_libraries(ctfdump.host PRIVATE libelf.host libctf.host ${ZLIB_LIBRARY_RELEASE})
-set_property(TARGET ctfdump.host PROPERTY CXX_STANDARD 14)
+set_property(TARGET host_ctfdump PROPERTY OUTPUT_NAME "ctfdump")
+target_include_directories(host_ctfdump PRIVATE ../include ../include/sys ../libelf)
+target_link_libraries(host_ctfdump PRIVATE libelf.host libctf.host ${ZLIB_LIBRARY_RELEASE})
+set_property(TARGET host_ctfdump PROPERTY CXX_STANDARD 14)
 
-add_executable(ctfmerge.host)
-target_sources(ctfmerge.host PRIVATE
+add_executable(host_ctfmerge)
+target_sources(host_ctfmerge PRIVATE
     alist.cpp
     array.c
     atom.cpp
@@ -85,6 +87,7 @@ target_sources(ctfmerge.host PRIVATE
     utils.c
 )
 
-target_include_directories(ctfmerge.host PRIVATE ../include ../include/sys ../libelf)
-target_link_libraries(ctfmerge.host PRIVATE libelf.host libdwarf.host libctf.host ${ZLIB_LIBRARY_RELEASE})
-set_property(TARGET ctfmerge.host PROPERTY CXX_STANDARD 14)
+set_property(TARGET host_ctfmerge PROPERTY OUTPUT_NAME ctfmerge)
+target_include_directories(host_ctfmerge PRIVATE ../include ../include/sys ../libelf)
+target_link_libraries(host_ctfmerge PRIVATE libelf.host libdwarf.host libctf.host ${ZLIB_LIBRARY_RELEASE})
+set_property(TARGET host_ctfmerge PROPERTY CXX_STANDARD 14)

--- a/tools/xar/CMakeLists.txt
+++ b/tools/xar/CMakeLists.txt
@@ -27,6 +27,7 @@ target_sources(host_libxar PRIVATE
     lib/util.c
     lib/zxar.c
 )
+set_property(TARGET host_libxar PROPERTY OUTPUT_NAME xar)
 target_include_directories(host_libxar PUBLIC include)
 target_include_directories(host_libxar PRIVATE ${OPENSSL_INCLUDE_DIR} ${LIBXML2_INCLUDE_DIR})
 target_link_libraries(host_libxar PRIVATE ZLIB::ZLIB LibXml2::LibXml2)
@@ -35,4 +36,5 @@ add_executable(host_xar)
 target_sources(host_xar PRIVATE
     src/xar.c
 )
+set_property(TARGET host_xar PROPERTY OUTPUT_NAME xar)
 target_link_libraries(host_xar PRIVATE host_libxar OpenSSL::SSL OpenSSL::Crypto ZLIB::ZLIB LibXml2::LibXml2)


### PR DESCRIPTION
This PR standardizes the name of all host tools on the `host_something` syntax. References to `something.host` and `darwin_something` have been removed. Also updated the OUTPUT_NAME for the tools targets to remove the `host_` prefix from the file names.