### PR TITLE
Suppress pointless warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,7 @@ include(cmake/get_target_dependencies.cmake)
 include(cmake/install_helpers.cmake)
 include(cmake/kext.cmake)
 include(cmake/mig.cmake)
+include(cmake/suppress_warnings.cmake)
 
 add_subdirectory(projects)
 add_subdirectory(src)

--- a/cmake/suppress_warnings.cmake
+++ b/cmake/suppress_warnings.cmake
@@ -1,0 +1,4 @@
+macro(suppress_warnings target)
+    target_compile_options(${target} PRIVATE -w)
+    target_link_options(${target} PRIVATE -w)
+endmacro()

--- a/tools/cctools/ld64/src/ld/parsers/CMakeLists.txt
+++ b/tools/cctools/ld64/src/ld/parsers/CMakeLists.txt
@@ -20,3 +20,4 @@ target_include_directories(host_ld_libparsers PRIVATE
 )
 target_link_libraries(host_ld_libparsers PRIVATE host_ld_helper)
 set_property(TARGET host_ld_libparsers PROPERTY CXX_STANDARD 11)
+suppress_warnings(host_ld_libparsers)

--- a/tools/cctools/ld64/src/ld/passes/CMakeLists.txt
+++ b/tools/cctools/ld64/src/ld/passes/CMakeLists.txt
@@ -29,3 +29,4 @@ target_include_directories(host_ld_libpasses PRIVATE
     ../../..
 )
 set_property(TARGET host_ld_libpasses PROPERTY CXX_STANDARD 11)
+suppress_warnings(host_ld_libpasses)

--- a/tools/cctools/misc/CMakeLists.txt
+++ b/tools/cctools/misc/CMakeLists.txt
@@ -29,6 +29,11 @@ cctools_misc_executable(cmpdylib)
 cctools_misc_executable(inout)
 cctools_misc_executable(vtool)
 
+suppress_warnings(host_bitcode_strip)
+suppress_warnings(host_install_name_tool)
+suppress_warnings(host_strip)
+suppress_warnings(host_vtool)
+
 # Special cases
 add_executable(host_nmedit strip.c)
 target_link_libraries(host_nmedit PRIVATE host_libmacho host_libstuff)

--- a/tools/dtrace_ctf/tools/CMakeLists.txt
+++ b/tools/dtrace_ctf/tools/CMakeLists.txt
@@ -30,6 +30,7 @@ set_property(TARGET host_ctfconvert PROPERTY OUTPUT_NAME "ctfconvert")
 target_include_directories(host_ctfconvert PRIVATE ../include ../include/sys ../libelf)
 target_link_libraries(host_ctfconvert PRIVATE libelf.host libdwarf.host libctf.host ${ZLIB_LIBRARY_RELEASE})
 set_property(TARGET host_ctfconvert PROPERTY CXX_STANDARD 14)
+suppress_warnings(host_ctfconvert)
 
 add_executable(host_ctfdump)
 target_sources(host_ctfdump PRIVATE
@@ -59,6 +60,7 @@ set_property(TARGET host_ctfdump PROPERTY OUTPUT_NAME "ctfdump")
 target_include_directories(host_ctfdump PRIVATE ../include ../include/sys ../libelf)
 target_link_libraries(host_ctfdump PRIVATE libelf.host libctf.host ${ZLIB_LIBRARY_RELEASE})
 set_property(TARGET host_ctfdump PROPERTY CXX_STANDARD 14)
+suppress_warnings(host_ctfdump)
 
 add_executable(host_ctfmerge)
 target_sources(host_ctfmerge PRIVATE
@@ -91,3 +93,4 @@ set_property(TARGET host_ctfmerge PROPERTY OUTPUT_NAME ctfmerge)
 target_include_directories(host_ctfmerge PRIVATE ../include ../include/sys ../libelf)
 target_link_libraries(host_ctfmerge PRIVATE libelf.host libdwarf.host libctf.host ${ZLIB_LIBRARY_RELEASE})
 set_property(TARGET host_ctfmerge PROPERTY CXX_STANDARD 14)
+suppress_warnings(host_ctfmerge)

--- a/tools/xar/CMakeLists.txt
+++ b/tools/xar/CMakeLists.txt
@@ -31,6 +31,7 @@ set_property(TARGET host_libxar PROPERTY OUTPUT_NAME xar)
 target_include_directories(host_libxar PUBLIC include)
 target_include_directories(host_libxar PRIVATE ${OPENSSL_INCLUDE_DIR} ${LIBXML2_INCLUDE_DIR})
 target_link_libraries(host_libxar PRIVATE ZLIB::ZLIB LibXml2::LibXml2)
+suppress_warnings(host_libxar)
 
 add_executable(host_xar)
 target_sources(host_xar PRIVATE


### PR DESCRIPTION
macOS’s clang is one of the more picky compilers out there. It emits a lot of pointless warnings in code that is not ours and therefore not developed solely for macOS. In particular, `sprintf()` is used in any number of places, and each produces a warning. Other warnings are generated as well.

This PR instructs the compiler to suppress all warnings in targets I have identified as problematic.