### PR TITLE
Fix today’s build blockers

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -4,6 +4,10 @@
 # every C file. Don't do this.
 add_compile_options(-Wno-overriding-t-option)
 
+# This warning is emitted by Clang for no good reason, given that it doesn't
+# impact compilation in any way, and produces a lot of log spam.
+add_compile_options(-Wno-undef-prefix)
+
 add_definitions(-DTARGET_OS_MACOSX=1)
 
 add_subdirectory(Kernel)

--- a/src/Libraries/libSystem/libsystem_kernel/wrappers/libproc/libproc.c
+++ b/src/Libraries/libSystem/libsystem_kernel/wrappers/libproc/libproc.c
@@ -292,7 +292,7 @@ proc_pidpath_audittoken(audit_token_t *audittoken, void * buffer, uint32_t buffe
 	int idversion = audittoken->val[7];
 
 	retval = __proc_info_extended_id(PROC_INFO_CALL_PIDINFO, pid, PROC_PIDPATHINFO, PIF_COMPARE_IDVERSION, (uint64_t)idversion,
-	    (uint64_t)0, buffer, buffersize);
+	    (uint64_t)0, (user_addr_t)buffer, buffersize);
 	if (retval != -1) {
 		len = (int)strlen(buffer);
 		return len;

--- a/src/Libraries/libSystem/libsystem_kernel/wrappers/system-version-compat.c
+++ b/src/Libraries/libSystem/libsystem_kernel/wrappers/system-version-compat.c
@@ -138,7 +138,7 @@ int
 _system_version_compat_open_shim(int opened_fd, int openat_fd, const char *orig_path, int oflag, mode_t mode,
     int (*close_syscall)(int), int (*open_syscall)(const char *, int, mode_t),
     int (*openat_syscall)(int, const char *, int, mode_t),
-    int (*fcntl_syscall)(int, int, long))
+    int (*fcntl_syscall)(int, int, void *))
 {
 	/* stash the errno from the original open{at} call */
 	int stashed_errno = errno;
@@ -146,7 +146,7 @@ _system_version_compat_open_shim(int opened_fd, int openat_fd, const char *orig_
 	size_t path_str_len = strnlen(orig_path, sizeof(new_path));
 
 	/* Resolve the full path of the file we've opened */
-	if (fcntl_syscall(opened_fd, F_GETPATH, new_path)) {
+	if (fcntl_syscall(opened_fd, F_GETPATH, (void *)&new_path)) {
 		if (errno == EINTR) {
 			/* If we got EINTR, we close the file that was opened and return -1 & EINTR */
 			close_syscall(opened_fd);


### PR DESCRIPTION
Apple updates their compiler so often that new compiler errors surface regularly. My fixes are designed *only* to get the code to compile; this code may introduce run-time bugs that will cause problems later.