### PR TITLE
Some minor cleanup

### DIFF
--- a/cmake/suppress_warnings.cmake
+++ b/cmake/suppress_warnings.cmake
@@ -1,4 +1,4 @@
-macro(suppress_warnings target)
+macro(suppress_all_warnings target)
     target_compile_options(${target} PRIVATE -w)
     target_link_options(${target} PRIVATE -w)
 endmacro()

--- a/src/Kernel/CMakeLists.txt
+++ b/src/Kernel/CMakeLists.txt
@@ -1,3 +1,4 @@
 add_subdirectory(Extensions)
 add_subdirectory(libkmod)
+add_subdirectory(libfirehose_kernel)
 add_subdirectory(xnu)

--- a/src/Kernel/libfirehose_kernel/CMakeLists.txt
+++ b/src/Kernel/libfirehose_kernel/CMakeLists.txt
@@ -1,0 +1,14 @@
+add_darwin_static_library(libfirehose_kernel)
+target_sources(libfirehose_kernel PRIVATE
+    src/firehose_buffer.c
+)
+
+target_include_directories(libfirehose_kernel PUBLIC include)
+target_compile_definitions(libfirehose_kernel PRIVATE
+    KERNEL=1 DISPATCH_USE_DTRACE=0 OS_ATOMIC_CONFIG_MEMORY_ORDER_DEPENDENCY=1
+    OS_ATOMIC_CONFIG_MEMORY_ORDER_DEPENDENCY=1 OS_ATOMIC_CONFIG_STARVATION_FREE_ONLY=0)
+target_compile_options(libfirehose_kernel PRIVATE -mkernel -Wno-packed -Wno-error=implicit-function-declaration -Wno-implicit-function-declaration)
+target_link_libraries(libfirehose_kernel PRIVATE AvailabilityHeaders xnu_private_headers)
+target_link_libraries(libfirehose_kernel PRIVATE xnu_kernel_headers xnu_kernel_private_headers)
+target_link_libraries(libfirehose_kernel PRIVATE libplatform_headers libplatform_private_headers)
+target_link_libraries(libfirehose_kernel PRIVATE pthread_common_headers pthread_common_private_headers)

--- a/src/Kernel/libfirehose_kernel/include/os/firehose_buffer_private.h
+++ b/src/Kernel/libfirehose_kernel/include/os/firehose_buffer_private.h
@@ -1,0 +1,161 @@
+/*
+ * Copyright (c) 2015 Apple Inc. All rights reserved.
+ *
+ * @APPLE_APACHE_LICENSE_HEADER_START@
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @APPLE_APACHE_LICENSE_HEADER_END@
+ */
+
+#ifndef __FIREHOSE_BUFFER_PRIVATE__
+#define __FIREHOSE_BUFFER_PRIVATE__
+
+#if OS_FIREHOSE_SPI
+#ifdef KERNEL
+#include <stdint.h>
+#else
+#include <os/base.h>
+#include <os/availability.h>
+#include <os/base_private.h>
+#include <dispatch/dispatch.h>
+#endif
+
+#define OS_FIREHOSE_SPI_VERSION 20180226
+
+/*!
+ * @group Firehose SPI
+ * SPI intended for logd only
+ * Layout of structs is subject to change without notice
+ */
+
+#define FIREHOSE_BUFFER_LIBTRACE_HEADER_SIZE	2048ul
+#define FIREHOSE_BUFFER_KERNEL_MIN_CHUNK_COUNT	16
+#define FIREHOSE_BUFFER_KERNEL_MAX_CHUNK_COUNT	64
+
+typedef struct firehose_buffer_range_s {
+	uint16_t fbr_offset; // offset from the start of the buffer
+	uint16_t fbr_length;
+} *firehose_buffer_range_t;
+
+#ifdef KERNEL
+
+typedef struct firehose_chunk_s *firehose_chunk_t;
+
+// implemented by the kernel
+extern void __firehose_buffer_push_to_logd(firehose_buffer_t fb, bool for_io);
+extern void __firehose_critical_region_enter(void);
+extern void __firehose_critical_region_leave(void);
+extern void __firehose_allocate(vm_offset_t *addr, vm_size_t size);
+extern uint8_t __firehose_buffer_kernel_chunk_count;
+extern uint8_t __firehose_num_kernel_io_pages;
+
+#define FIREHOSE_BUFFER_KERNEL_DEFAULT_CHUNK_COUNT FIREHOSE_BUFFER_KERNEL_MIN_CHUNK_COUNT
+#define FIREHOSE_BUFFER_KERNEL_DEFAULT_IO_PAGES    8
+
+#define FIREHOSE_BUFFER_KERNEL_CHUNK_COUNT __firehose_buffer_kernel_chunk_count
+#define FIREHOSE_BUFFER_CHUNK_PREALLOCATED_COUNT (__firehose_buffer_kernel_chunk_count - 1) // the first chunk is the header
+
+// exported for the kernel
+firehose_tracepoint_t
+__firehose_buffer_tracepoint_reserve(uint64_t stamp, firehose_stream_t stream,
+		uint16_t pubsize, uint16_t privsize, uint8_t **privptr);
+
+void
+__firehose_buffer_tracepoint_flush(firehose_tracepoint_t vat,
+		firehose_tracepoint_id_u vatid);
+
+firehose_buffer_t
+__firehose_buffer_create(size_t *size);
+
+bool
+__firehose_merge_updates(firehose_push_reply_t update);
+
+int
+__firehose_kernel_configuration_valid(uint8_t chunk_count, uint8_t io_pages);
+
+#else
+
+#define __firehose_critical_region_enter()
+#define __firehose_critical_region_leave()
+
+OS_EXPORT
+const uint32_t _firehose_spi_version;
+
+OS_ALWAYS_INLINE
+static inline const uint8_t *
+_firehose_tracepoint_reader_init(firehose_chunk_t fc, const uint8_t **endptr)
+{
+	const uint8_t *start = fc->fc_data;
+	const uint8_t *end = fc->fc_start + fc->fc_pos.fcp_next_entry_offs;
+
+	if (end > fc->fc_start + FIREHOSE_CHUNK_SIZE) {
+		end = start;
+	}
+	*endptr = end;
+	return start;
+}
+
+OS_ALWAYS_INLINE
+static inline firehose_tracepoint_t
+_firehose_tracepoint_reader_next(const uint8_t **ptr, const uint8_t *end)
+{
+	const uint16_t ft_size = offsetof(struct firehose_tracepoint_s, ft_data);
+	struct ft_unaligned_s {
+		struct firehose_tracepoint_s ft;
+	} __attribute__((packed, aligned(1))) *uft;
+
+	do {
+		uft = (struct ft_unaligned_s *)*ptr;
+		if (uft->ft.ft_data >= end) {
+			// reached the end
+			return NULL;
+		}
+		if (!uft->ft.ft_length) {
+			// tracepoint write didn't even start
+			return NULL;
+		}
+		if (uft->ft.ft_length > end - uft->ft.ft_data) {
+			// invalid length
+			return NULL;
+		}
+		*ptr += roundup(ft_size + uft->ft.ft_length, 8);
+		// test whether write of the tracepoint was finished
+	} while (os_unlikely(uft->ft.ft_id.ftid_value == 0));
+
+	return (firehose_tracepoint_t)uft;
+}
+
+#define firehose_tracepoint_foreach(ft, fbc) \
+		for (const uint8_t *end, *p = _firehose_tracepoint_reader_init(fbc, &end); \
+				((ft) = _firehose_tracepoint_reader_next(&p, end)); )
+
+OS_ALWAYS_INLINE
+static inline bool
+firehose_buffer_range_validate(firehose_chunk_t fc, firehose_tracepoint_t ft,
+		firehose_buffer_range_t range)
+{
+	if (range->fbr_offset + range->fbr_length > FIREHOSE_CHUNK_SIZE) {
+		return false;
+	}
+	if (fc->fc_start + range->fbr_offset < ft->ft_data + ft->ft_length) {
+		return false;
+	}
+	return true;
+}
+
+#endif // !KERNEL
+
+#endif // OS_FIREHOSE_SPI
+
+#endif // __FIREHOSE_BUFFER_PRIVATE__

--- a/src/Kernel/libfirehose_kernel/src/firehose_buffer.c
+++ b/src/Kernel/libfirehose_kernel/src/firehose_buffer.c
@@ -1,0 +1,1465 @@
+/*
+ * Copyright (c) 2015 Apple Inc. All rights reserved.
+ *
+ * @APPLE_APACHE_LICENSE_HEADER_START@
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @APPLE_APACHE_LICENSE_HEADER_END@
+ */
+
+#include <os/atomic_private.h>
+#include <mach/vm_statistics.h> // VM_MEMORY_GENEALOGY
+
+#ifndef __LP64__
+// libdispatch has too many Double-Wide loads for this to be practical
+// so just rename everything to the wide variants
+#undef os_atomic_load
+#define os_atomic_load os_atomic_load_wide
+
+#undef os_atomic_store
+#define os_atomic_store os_atomic_store_wide
+#endif
+
+#ifdef KERNEL
+
+#define OS_VOUCHER_ACTIVITY_SPI_TYPES 1
+#define OS_FIREHOSE_SPI 1
+#define __OS_EXPOSE_INTERNALS_INDIRECT__ 1
+
+#define DISPATCH_PURE_C 1
+#ifndef os_likely
+#define os_likely(x) __builtin_expect(!!(x), 1)
+#endif
+#ifndef os_unlikely
+#define os_unlikely(x) __builtin_expect(!!(x), 0)
+#endif
+#define likely(x)   __builtin_expect(!!(x), 1)
+#define unlikely(x) __builtin_expect(!!(x), 0)
+
+#ifndef OS_FALLTHROUGH
+#define OS_FALLTHROUGH
+#endif
+
+#define DISPATCH_INTERNAL_CRASH(ac, msg) ({ panic(msg); __builtin_trap(); })
+
+#if defined(__x86_64__) || defined(__i386__)
+#define dispatch_hardware_pause() __asm__("pause")
+#elif (defined(__arm__) && defined(_ARM_ARCH_7) && defined(__thumb__)) || \
+		defined(__arm64__)
+#define dispatch_hardware_pause() __asm__("yield")
+#define dispatch_hardware_wfe()   __asm__("wfe")
+#else
+#define dispatch_hardware_pause() __asm__("")
+#endif
+
+#define _dispatch_wait_until(c) ({ \
+		__typeof__(c) _c; \
+		for (;;) { \
+			if (likely(_c = (c))) break; \
+			dispatch_hardware_pause(); \
+		} \
+		_c; })
+#define dispatch_compiler_barrier()  __asm__ __volatile__("" ::: "memory")
+
+typedef uint32_t dispatch_lock;
+typedef struct dispatch_gate_s {
+	dispatch_lock dgl_lock;
+} dispatch_gate_s, *dispatch_gate_t;
+#define DLOCK_LOCK_DATA_CONTENTION 0
+static void _dispatch_firehose_gate_wait(dispatch_gate_t l, uint32_t flags);
+
+#define fcp_quarntined fcp_quarantined
+
+#include <kern/debug.h>
+#include <machine/cpu_number.h>
+#include <kern/thread.h>
+#include <mach/port.h>
+#include <stdbool.h>
+#include <string.h>
+#include <sys/param.h>
+#include <sys/types.h>
+#include <vm/vm_kern.h>
+#include <firehose/firehose_types_private.h>
+#include <firehose/tracepoint_private.h>
+#include <firehose/chunk_private.h>
+#include "os/firehose_buffer_private.h"
+#include "firehose_buffer_internal.h"
+#include "firehose_inline_internal.h"
+#else
+#include "internal.h"
+#include "firehose.h" // MiG
+#include "firehose_replyServer.h" // MiG
+#endif
+
+#if OS_FIREHOSE_SPI
+
+#if __has_feature(c_static_assert)
+_Static_assert(sizeof(((firehose_stream_state_u *)NULL)->fss_gate) ==
+		sizeof(((firehose_stream_state_u *)NULL)->fss_allocator),
+		"fss_gate and fss_allocator alias");
+_Static_assert(offsetof(firehose_stream_state_u, fss_gate) ==
+		offsetof(firehose_stream_state_u, fss_allocator),
+		"fss_gate and fss_allocator alias");
+_Static_assert(sizeof(struct firehose_buffer_header_s) ==
+				FIREHOSE_CHUNK_SIZE,
+		"firehose buffer header must be 4k");
+_Static_assert(offsetof(struct firehose_buffer_header_s, fbh_unused) <=
+				FIREHOSE_CHUNK_SIZE - FIREHOSE_BUFFER_LIBTRACE_HEADER_SIZE,
+		"we must have enough space for the libtrace header");
+_Static_assert(powerof2(FIREHOSE_BUFFER_CHUNK_COUNT),
+		"CHUNK_COUNT Must be a power of two");
+_Static_assert(FIREHOSE_BUFFER_CHUNK_COUNT <= 64,
+		"CHUNK_COUNT must be less than 64 (bitmap in uint64_t)");
+#ifdef FIREHOSE_BUFFER_MADVISE_CHUNK_COUNT
+_Static_assert(powerof2(FIREHOSE_BUFFER_MADVISE_CHUNK_COUNT),
+		"madvise chunk count must be a power of two");
+#endif
+_Static_assert(sizeof(struct firehose_buffer_stream_s) == 128,
+		"firehose buffer stream must be small (single cacheline if possible)");
+_Static_assert(sizeof(struct firehose_tracepoint_s) == 24,
+		"tracepoint header should be exactly 24 bytes");
+#endif
+
+#ifdef KERNEL
+static firehose_buffer_t kernel_firehose_buffer = NULL;
+
+_Static_assert(FIREHOSE_BUFFER_KERNEL_MAX_CHUNK_COUNT == FIREHOSE_BUFFER_CHUNK_COUNT,
+		"FIREHOSE_BUFFER_KERNEL_MAX_CHUNK_COUNT must match FIREHOSE_BUFFER_CHUNK_COUNT");
+_Static_assert(FIREHOSE_BUFFER_KERNEL_DEFAULT_IO_PAGES <= FIREHOSE_BUFFER_KERNEL_DEFAULT_CHUNK_COUNT * 3 / 4,
+		"FIREHOSE_BUFFER_KERNEL_DEFAULT_IO_PAGES cannot exceed 3/4 of FIREHOSE_BUFFER_KERNEL_DEFAULT_CHUNK_COUNT");
+#endif
+
+#pragma mark -
+#pragma mark Client IPC to the log daemon
+#ifndef KERNEL
+
+static mach_port_t
+firehose_client_reconnect(firehose_buffer_t fb, mach_port_t oldsendp,
+		firehose_buffer_pushport_t pushport)
+{
+	mach_port_t cursendp = MACH_PORT_NULL;
+	mach_port_t mem_port = MACH_PORT_NULL, extra_info_port = MACH_PORT_NULL;
+	mach_vm_size_t extra_info_size = 0;
+	kern_return_t kr;
+	bool reconnecting = (oldsendp != MACH_PORT_NULL);
+
+	dispatch_assert(fb->fb_header.fbh_logd_port);
+	dispatch_assert(fb->fb_header.fbh_recvp);
+	dispatch_assert(fb->fb_header.fbh_uniquepid != 0);
+
+	_dispatch_unfair_lock_lock(&fb->fb_header.fbh_logd_lock);
+	cursendp = fb->fb_header.fbh_sendp[pushport];
+	if (cursendp != oldsendp || cursendp == MACH_PORT_DEAD) {
+		// someone beat us to reconnecting or logd was unloaded, just go away
+		goto unlock;
+	}
+
+	if (reconnecting) {
+		for (int i = 0; i < FIREHOSE_BUFFER_NPUSHPORTS; i++) {
+			mach_port_t spi = fb->fb_header.fbh_sendp[i];
+			dispatch_assert(spi);
+			// same trick as _xpc_pipe_dispose: keeping a send right maintains
+			// the name, so that we can destroy the receive right in case we
+			// still have it.
+			(void)firehose_mach_port_recv_dispose(spi, fb);
+			firehose_mach_port_send_release(spi);
+			fb->fb_header.fbh_sendp[i] = MACH_PORT_NULL;
+		}
+	}
+
+	/* Create a memory port for the buffer VM region */
+	vm_prot_t flags = VM_PROT_READ | MAP_MEM_VM_SHARE;
+	memory_object_size_t size = sizeof(union firehose_buffer_u);
+	mach_vm_address_t addr = (vm_address_t)fb;
+
+	kr = mach_make_memory_entry_64(mach_task_self(), &size, addr,
+			flags, &mem_port, MACH_PORT_NULL);
+	if (size < sizeof(union firehose_buffer_u)) {
+		DISPATCH_CLIENT_CRASH(size, "Invalid size for the firehose buffer");
+	}
+	if (unlikely(kr)) {
+		// the client probably has some form of memory corruption
+		// and/or a port leak
+		DISPATCH_CLIENT_CRASH(kr, "Unable to make memory port");
+	}
+
+	if (reconnecting && _voucher_libtrace_hooks->vah_get_reconnect_info) {
+		kr = _voucher_libtrace_hooks->vah_get_reconnect_info(&addr, &size);
+		if (likely(kr == KERN_SUCCESS) && addr && size) {
+			extra_info_size = size;
+			kr = mach_make_memory_entry_64(mach_task_self(), &size, addr,
+					flags, &extra_info_port, MACH_PORT_NULL);
+			if (unlikely(kr)) {
+				// the client probably has some form of memory corruption
+				// and/or a port leak
+				DISPATCH_CLIENT_CRASH(kr, "Unable to make memory port");
+			}
+			kr = mach_vm_deallocate(mach_task_self(), addr, size);
+			(void)dispatch_assume_zero(kr);
+		}
+	}
+
+	/* Create memory and IO communication ports to the logging daemon */
+	uint32_t opts = MPO_CONTEXT_AS_GUARD | MPO_TEMPOWNER | MPO_INSERT_SEND_RIGHT;
+	mach_port_t sendp[FIREHOSE_BUFFER_NPUSHPORTS];
+	for (int i = 0; i < FIREHOSE_BUFFER_NPUSHPORTS; i++) {
+		sendp[i] = firehose_mach_port_allocate(opts, 1, fb);
+	}
+	cursendp = sendp[pushport];
+
+	/* Call the firehose_register() MIG routine */
+	kr = firehose_send_register(fb->fb_header.fbh_logd_port, mem_port,
+			sizeof(union firehose_buffer_u),
+			sendp[FIREHOSE_BUFFER_PUSHPORT_MEM],
+			sendp[FIREHOSE_BUFFER_PUSHPORT_IO], fb->fb_header.fbh_recvp,
+			extra_info_port, extra_info_size);
+	if (likely(kr == KERN_SUCCESS)) {
+		for (int i = 0; i < FIREHOSE_BUFFER_NPUSHPORTS; i++) {
+			fb->fb_header.fbh_sendp[i] = sendp[i];
+		}
+	} else if (unlikely(kr == MACH_SEND_INVALID_DEST)) {
+		// MACH_SEND_INVALID_DEST here means that logd's boostrap port
+		// turned into a dead name, which in turn means that logd has been
+		// unloaded. The only option here, is to give up permanently.
+		for (int i = 0; i < FIREHOSE_BUFFER_NPUSHPORTS; i++) {
+			// same trick as _xpc_pipe_dispose: keeping a send right maintains
+			// the name, so that we can destroy the receive right in case we
+			// still have it.
+			(void)firehose_mach_port_recv_dispose(sendp[i], fb);
+			firehose_mach_port_send_release(sendp[i]);
+			fb->fb_header.fbh_sendp[i] = MACH_PORT_DEAD;
+		}
+		cursendp = MACH_PORT_DEAD;
+		firehose_mach_port_send_release(mem_port);
+		if (extra_info_port) firehose_mach_port_send_release(extra_info_port);
+	} else {
+		// the client probably has some form of memory corruption
+		// and/or a port leak
+		DISPATCH_CLIENT_CRASH(kr, "Unable to register with logd");
+	}
+
+unlock:
+	_dispatch_unfair_lock_unlock(&fb->fb_header.fbh_logd_lock);
+	return cursendp;
+}
+
+static void
+firehose_buffer_update_limits_unlocked(firehose_buffer_t fb)
+{
+	firehose_bank_state_u old, new;
+	firehose_buffer_bank_t fbb = &fb->fb_header.fbh_bank;
+	unsigned long fbb_flags = fbb->fbb_flags;
+	uint16_t io_streams = 0, mem_streams = 0;
+	uint16_t total = 0;
+
+	for (size_t i = 0; i < countof(fb->fb_header.fbh_stream); i++) {
+		firehose_buffer_stream_t fbs = fb->fb_header.fbh_stream + i;
+
+		if (fbs->fbs_state.fss_current == FIREHOSE_STREAM_STATE_PRISTINE) {
+			continue;
+		}
+		if ((1UL << i) & firehose_stream_uses_io_bank) {
+			io_streams++;
+		} else {
+			mem_streams++;
+		}
+	}
+
+	if (fbb_flags & FIREHOSE_BUFFER_BANK_FLAG_LOW_MEMORY) {
+		if (fbb_flags & FIREHOSE_BUFFER_BANK_FLAG_HIGH_RATE) {
+			total = 1 + 4 * mem_streams + io_streams;		// usually 10
+		} else {
+			total = 1 + 2 + mem_streams + io_streams;		// usually 6
+		}
+	} else {
+		if (fbb_flags & FIREHOSE_BUFFER_BANK_FLAG_HIGH_RATE) {
+			total = 1 + 6 * mem_streams + 3 * io_streams;	// usually 16
+		} else {
+			total = 1 + 2 * (mem_streams + io_streams);		// usually 7
+		}
+	}
+
+	uint16_t ratio = (uint16_t)(PAGE_SIZE / FIREHOSE_CHUNK_SIZE);
+	if (ratio > 1) {
+		total = roundup(total, ratio);
+	}
+	total = MAX(total, FIREHOSE_BUFFER_CHUNK_PREALLOCATED_COUNT);
+	if (!(fbb_flags & FIREHOSE_BUFFER_BANK_FLAG_LOW_MEMORY)) {
+		total = MAX(total, TARGET_OS_IPHONE ? 8 : 12);
+	}
+
+	new = (firehose_bank_state_u) {
+		.fbs_max_ref = (firehose_chunk_ref_t)(total + 1),
+		.fbs_mem_bank = total - 1,
+		.fbs_io_bank  = MAX(3 * total / 8, 2 * io_streams),
+	};
+
+	old = fbb->fbb_limits;
+	fbb->fbb_limits = new;
+	if (old.fbs_atomic_state == new.fbs_atomic_state) {
+		return;
+	}
+	os_atomic_add(&fb->fb_header.fbh_bank.fbb_state.fbs_atomic_state,
+			new.fbs_atomic_state - old.fbs_atomic_state, relaxed);
+}
+#endif // !KERNEL
+
+firehose_buffer_t
+firehose_buffer_create(mach_port_t logd_port, uint64_t unique_pid,
+		unsigned long bank_flags)
+{
+	firehose_buffer_header_t fbh;
+	firehose_buffer_t fb;
+
+#ifndef KERNEL
+	mach_vm_address_t vm_addr = 0;
+	kern_return_t kr;
+
+	vm_addr = vm_page_size;
+	const size_t madvise_bytes = FIREHOSE_BUFFER_MADVISE_CHUNK_COUNT *
+			FIREHOSE_CHUNK_SIZE;
+	if (unlikely(madvise_bytes % PAGE_SIZE)) {
+		DISPATCH_INTERNAL_CRASH(madvise_bytes,
+				"Invalid values for MADVISE_CHUNK_COUNT / CHUNK_SIZE");
+	}
+
+	kr = mach_vm_map(mach_task_self(), &vm_addr, sizeof(*fb), 0,
+			VM_FLAGS_ANYWHERE | VM_FLAGS_PURGABLE |
+			VM_MAKE_TAG(VM_MEMORY_GENEALOGY), MEMORY_OBJECT_NULL, 0, FALSE,
+			VM_PROT_DEFAULT, VM_PROT_ALL, VM_INHERIT_NONE);
+	if (unlikely(kr)) {
+		if (kr != KERN_NO_SPACE) dispatch_assume_zero(kr);
+		firehose_mach_port_send_release(logd_port);
+		return NULL;
+	}
+
+	uint32_t opts = MPO_CONTEXT_AS_GUARD | MPO_STRICT | MPO_INSERT_SEND_RIGHT;
+#else
+	vm_offset_t vm_addr = 0;
+	vm_size_t size;
+
+	size = FIREHOSE_BUFFER_KERNEL_CHUNK_COUNT * FIREHOSE_CHUNK_SIZE;
+	__firehose_allocate(&vm_addr, size);
+
+	(void)logd_port; (void)unique_pid;
+#endif // KERNEL
+
+	fb = (firehose_buffer_t)vm_addr;
+	fbh = &fb->fb_header;
+#ifndef KERNEL
+	fbh->fbh_logd_port = logd_port;
+	fbh->fbh_pid = getpid();
+	fbh->fbh_uniquepid = unique_pid;
+	fbh->fbh_recvp = firehose_mach_port_allocate(opts, MACH_PORT_QLIMIT_BASIC,
+			fb);
+#endif // !KERNEL
+	fbh->fbh_spi_version = OS_FIREHOSE_SPI_VERSION;
+	fbh->fbh_bank.fbb_flags = bank_flags;
+
+#ifndef KERNEL
+	for (size_t i = 0; i < countof(fbh->fbh_stream); i++) {
+		firehose_buffer_stream_t fbs = fbh->fbh_stream + i;
+		if (i != firehose_stream_metadata) {
+			fbs->fbs_state.fss_current = FIREHOSE_STREAM_STATE_PRISTINE;
+		}
+	}
+	firehose_buffer_update_limits_unlocked(fb);
+#else
+	uint16_t total = FIREHOSE_BUFFER_CHUNK_PREALLOCATED_COUNT;
+	const uint16_t num_kernel_io_pages = __firehose_num_kernel_io_pages;
+	uint16_t io_pages = num_kernel_io_pages;
+	fbh->fbh_bank.fbb_state = (firehose_bank_state_u){
+		.fbs_max_ref = (firehose_chunk_ref_t)(total + 1),
+		.fbs_io_bank = io_pages,
+		.fbs_mem_bank = total - io_pages,
+	};
+	fbh->fbh_bank.fbb_limits = fbh->fbh_bank.fbb_state;
+#endif // KERNEL
+
+	// now pre-allocate some chunks in the ring directly
+#ifdef KERNEL
+	const uint16_t pre_allocated = FIREHOSE_BUFFER_CHUNK_PREALLOCATED_COUNT - 1;
+#else
+	const uint16_t pre_allocated = FIREHOSE_BUFFER_CHUNK_PREALLOCATED_COUNT;
+#endif
+
+	fbh->fbh_bank.fbb_bitmap = (1U << (1 + pre_allocated)) - 1;
+
+	for (uint16_t i = 0; i < pre_allocated; i++) {
+		fbh->fbh_mem_ring[i] = i + 1;
+	}
+	fbh->fbh_bank.fbb_mem_flushed = pre_allocated;
+	fbh->fbh_ring_mem_head = pre_allocated;
+
+
+#ifdef KERNEL
+	// install the early boot page as the current one for persist
+	fbh->fbh_stream[firehose_stream_persist].fbs_state.fss_current =
+			FIREHOSE_BUFFER_CHUNK_PREALLOCATED_COUNT;
+	fbh->fbh_bank.fbb_state.fbs_io_bank -= 1;
+#endif
+
+	fbh->fbh_ring_tail = (firehose_ring_tail_u){
+		.frp_mem_flushed = pre_allocated,
+	};
+	return fb;
+}
+
+#ifndef KERNEL
+static char const * const _firehose_key = "firehose";
+
+static bool
+firehose_drain_notifications_once(firehose_buffer_t fb)
+{
+	mach_msg_options_t opts = MACH_RCV_MSG | MACH_RCV_TIMEOUT |
+			MACH_RCV_TRAILER_ELEMENTS(MACH_RCV_TRAILER_CTX) | MACH_RCV_LARGE |
+			MACH_RCV_TRAILER_TYPE(MACH_MSG_TRAILER_FORMAT_0);
+
+	const size_t maxsize =
+			sizeof(union __RequestUnion__firehose_client_firehoseReply_subsystem);
+	const size_t maxreplysize =
+			sizeof(union __ReplyUnion__firehose_client_firehoseReply_subsystem);
+	mach_msg_size_t rcv_size = maxsize + MAX_TRAILER_SIZE;
+	mig_reply_error_t *msg = alloca(rcv_size);
+	kern_return_t kr;
+
+	kr = mach_msg(&msg->Head, opts, 0, rcv_size, fb->fb_header.fbh_recvp, 0, 0);
+
+	if (kr == KERN_SUCCESS) {
+		dispatch_thread_context_s firehose_ctxt = {
+			.dtc_key = _firehose_key,
+			.dtc_fb = fb,
+		};
+		_dispatch_thread_context_push(&firehose_ctxt);
+		firehose_mig_server(firehoseReply_server, maxreplysize, &msg->Head);
+		_dispatch_thread_context_pop(&firehose_ctxt);
+	} else if (kr != MACH_RCV_TIMED_OUT) {
+		DISPATCH_CLIENT_CRASH(kr, "firehose_drain_notifications_once() failed");
+	}
+	return kr == KERN_SUCCESS;
+}
+
+static void
+firehose_client_send_push_async(firehose_buffer_t fb, qos_class_t qos,
+		bool for_io)
+{
+	firehose_buffer_pushport_t pushport = for_io;
+	mach_port_t sendp = fb->fb_header.fbh_sendp[pushport];
+	kern_return_t kr = KERN_FAILURE;
+
+	if (unlikely(sendp == MACH_PORT_DEAD)) {
+		return;
+	}
+
+	if (likely(sendp)) {
+		kr = firehose_send_push_async(sendp, qos, 0);
+		if (likely(kr == KERN_SUCCESS || kr == MACH_SEND_TIMED_OUT)) {
+			return;
+		}
+		if (kr != MACH_SEND_INVALID_DEST) {
+			DISPATCH_VERIFY_MIG(kr);
+			dispatch_assume_zero(kr);
+		}
+	}
+
+	sendp = firehose_client_reconnect(fb, sendp, pushport);
+	if (likely(MACH_PORT_VALID(sendp))) {
+		kr = firehose_send_push_async(sendp, qos, 0);
+		if (likely(kr == KERN_SUCCESS || kr == MACH_SEND_TIMED_OUT)) {
+			return;
+		}
+		if (kr != MACH_SEND_INVALID_DEST) {
+			DISPATCH_VERIFY_MIG(kr);
+			dispatch_assume_zero(kr);
+		}
+	}
+}
+
+OS_NOINLINE
+static void
+firehose_client_start_quarantine(firehose_buffer_t fb)
+{
+	if (_voucher_libtrace_hooks->vah_version < 5) return;
+	if (!_voucher_libtrace_hooks->vah_quarantine_starts) return;
+
+	_voucher_libtrace_hooks->vah_quarantine_starts();
+
+	fb->fb_header.fbh_quarantined = true;
+	firehose_buffer_stream_flush(fb, firehose_stream_special);
+	firehose_buffer_stream_flush(fb, firehose_stream_persist);
+	firehose_buffer_stream_flush(fb, firehose_stream_memory);
+}
+#endif // !KERNEL
+
+static void
+firehose_client_merge_updates(firehose_buffer_t fb, bool async_notif,
+		firehose_push_reply_t reply, bool quarantined,
+		firehose_bank_state_u *state_out)
+{
+	firehose_buffer_header_t fbh = &fb->fb_header;
+	firehose_bank_state_u state;
+	firehose_ring_tail_u otail, ntail;
+	uint64_t old_flushed_pos, bank_updates;
+	uint16_t io_delta = 0;
+	uint16_t mem_delta = 0;
+
+	if (quarantined) {
+#ifndef KERNEL
+		// this isn't a dispatch_once so that the upcall to libtrace
+		// can actually log itself without blocking on the gate.
+		if (os_atomic_load(&fbh->fbh_quarantined_state, relaxed) ==
+				FBH_QUARANTINE_NONE) {
+			os_atomic_cmpxchg(&fbh->fbh_quarantined_state, FBH_QUARANTINE_NONE,
+					FBH_QUARANTINE_PENDING, relaxed);
+		}
+#endif
+	}
+
+	if (firehose_atomic_maxv(&fbh->fbh_bank.fbb_mem_flushed,
+			reply.fpr_mem_flushed_pos, &old_flushed_pos, relaxed)) {
+		mem_delta = (uint16_t)(reply.fpr_mem_flushed_pos - old_flushed_pos);
+	}
+	if (firehose_atomic_maxv(&fbh->fbh_bank.fbb_io_flushed,
+			reply.fpr_io_flushed_pos, &old_flushed_pos, relaxed)) {
+		io_delta = (uint16_t)(reply.fpr_io_flushed_pos - old_flushed_pos);
+	}
+#ifndef KERNEL
+	_dispatch_debug("client side: mem: +%d->%llx, io: +%d->%llx",
+			mem_delta, reply.fpr_mem_flushed_pos,
+			io_delta, reply.fpr_io_flushed_pos);
+#endif
+
+	if (!mem_delta && !io_delta) {
+		if (state_out) {
+			state_out->fbs_atomic_state = os_atomic_load(
+					&fbh->fbh_bank.fbb_state.fbs_atomic_state, relaxed);
+		}
+		return;
+	}
+
+	__firehose_critical_region_enter();
+	os_atomic_rmw_loop(&fbh->fbh_ring_tail.frp_atomic_tail,
+			otail.frp_atomic_tail, ntail.frp_atomic_tail, relaxed, {
+		ntail = otail;
+		// overflow handles the generation wraps
+		ntail.frp_io_flushed += io_delta;
+		ntail.frp_mem_flushed += mem_delta;
+	});
+
+	bank_updates = ((uint64_t)mem_delta << FIREHOSE_BANK_SHIFT(0)) |
+			((uint64_t)io_delta << FIREHOSE_BANK_SHIFT(1));
+	state.fbs_atomic_state = os_atomic_add(
+			&fbh->fbh_bank.fbb_state.fbs_atomic_state, bank_updates, release);
+	__firehose_critical_region_leave();
+
+	if (state_out) *state_out = state;
+
+	if (async_notif) {
+		if (io_delta) {
+			os_atomic_add(&fbh->fbh_bank.fbb_io_notifs, 1u, relaxed);
+		}
+		if (mem_delta) {
+			os_atomic_add(&fbh->fbh_bank.fbb_mem_notifs, 1u, relaxed);
+		}
+	}
+}
+
+#ifndef KERNEL
+void *
+firehose_buffer_get_logging_prefs(firehose_buffer_t fb, size_t *length)
+{
+	mach_port_t sendp = fb->fb_header.fbh_logd_port;
+	mach_port_t mem_port = MACH_PORT_NULL;
+	mach_vm_size_t size = 0;
+	mach_vm_address_t addr = 0;
+	kern_return_t kr;
+
+	if (unlikely(!MACH_PORT_VALID(sendp))) {
+		*length = 0;
+		return NULL;
+	}
+
+	kr = firehose_send_get_logging_prefs(sendp, &mem_port, &size);
+	if (unlikely(kr != KERN_SUCCESS)) {
+		if (kr != MACH_SEND_INVALID_DEST) {
+			DISPATCH_VERIFY_MIG(kr);
+			dispatch_assume_zero(kr);
+		}
+		*length = 0;
+		return NULL;
+	}
+
+	/* Map the memory handle into the server address space */
+	kr = mach_vm_map(mach_task_self(), &addr, size, 0,
+			VM_FLAGS_ANYWHERE, mem_port, 0, FALSE,
+			VM_PROT_READ, VM_PROT_READ, VM_INHERIT_NONE);
+	DISPATCH_VERIFY_MIG(kr);
+	if (dispatch_assume_zero(kr)) {
+		addr = 0;
+		size = 0;
+	}
+	kr = mach_port_deallocate(mach_task_self(), mem_port);
+	DISPATCH_VERIFY_MIG(kr);
+	dispatch_assume_zero(kr);
+
+	*length = (size_t)size;
+	return (void *)addr;
+}
+
+bool
+firehose_buffer_should_send_strings(firehose_buffer_t fb)
+{
+	mach_port_t sendp = fb->fb_header.fbh_sendp[FIREHOSE_BUFFER_PUSHPORT_MEM];
+	kern_return_t kr;
+	boolean_t result = false;
+
+	if (unlikely(sendp == MACH_PORT_DEAD)) {
+		return false;
+	}
+
+	if (likely(sendp)) {
+		kr = firehose_send_should_send_strings(sendp, &result);
+		if (likely(kr == KERN_SUCCESS)) {
+			return result;
+		}
+		if (kr != MACH_SEND_INVALID_DEST) {
+			DISPATCH_VERIFY_MIG(kr);
+			dispatch_assume_zero(kr);
+		}
+	}
+
+	sendp = firehose_client_reconnect(fb, sendp, FIREHOSE_BUFFER_PUSHPORT_MEM);
+	if (likely(MACH_PORT_VALID(sendp))) {
+		kr = firehose_send_should_send_strings(sendp, &result);
+		if (likely(kr == KERN_SUCCESS)) {
+			return result;
+		}
+		if (kr != MACH_SEND_INVALID_DEST) {
+			DISPATCH_VERIFY_MIG(kr);
+			dispatch_assume_zero(kr);
+		}
+	}
+	return false;
+}
+
+OS_NOT_TAIL_CALLED OS_NOINLINE
+static void
+firehose_client_send_push_and_wait(firehose_buffer_t fb, bool for_io,
+		firehose_bank_state_u *state_out)
+{
+	firehose_buffer_pushport_t pushport = for_io;
+	mach_port_t sendp = fb->fb_header.fbh_sendp[pushport];
+	firehose_push_reply_t push_reply = { };
+	boolean_t quarantined = false;
+	kern_return_t kr;
+
+	if (unlikely(sendp == MACH_PORT_DEAD)) {
+		return;
+	}
+	if (likely(sendp)) {
+		kr = firehose_send_push_and_wait(sendp, &push_reply, &quarantined);
+		if (likely(kr == KERN_SUCCESS)) {
+			goto success;
+		}
+		if (kr != MACH_SEND_INVALID_DEST) {
+			DISPATCH_VERIFY_MIG(kr);
+			dispatch_assume_zero(kr);
+		}
+	}
+
+	sendp = firehose_client_reconnect(fb, sendp, pushport);
+	if (likely(MACH_PORT_VALID(sendp))) {
+		kr = firehose_send_push_and_wait(sendp, &push_reply, &quarantined);
+		if (likely(kr == KERN_SUCCESS)) {
+			goto success;
+		}
+		if (kr != MACH_SEND_INVALID_DEST) {
+			DISPATCH_VERIFY_MIG(kr);
+			dispatch_assume_zero(kr);
+		}
+	}
+
+	if (state_out) {
+		state_out->fbs_atomic_state = os_atomic_load(
+				&fb->fb_header.fbh_bank.fbb_state.fbs_atomic_state, relaxed);
+	}
+	return;
+
+success:
+	if (memcmp(&push_reply, &FIREHOSE_PUSH_REPLY_CORRUPTED,
+			sizeof(push_reply)) == 0) {
+		// TODO: find out the actual cause and log it
+		DISPATCH_CLIENT_CRASH(0, "Memory corruption in the logging buffers");
+	}
+
+	if (for_io) {
+		os_atomic_inc(&fb->fb_header.fbh_bank.fbb_io_sync_pushes, relaxed);
+	} else {
+		os_atomic_inc(&fb->fb_header.fbh_bank.fbb_mem_sync_pushes, relaxed);
+	}
+	// TODO <rdar://problem/22963876>
+	//
+	// use fbb_*_flushes and fbb_*_sync_pushes to decide to dynamically
+	// allow using more buffers, if not under memory pressure.
+	//
+	// There only is a point for multithreaded clients if:
+	// - enough samples (total_flushes above some limits)
+	// - the ratio is really bad (a push per cycle is definitely a problem)
+	return firehose_client_merge_updates(fb, false, push_reply, quarantined,
+			state_out);
+}
+
+OS_NOT_TAIL_CALLED OS_NOINLINE
+static void
+__FIREHOSE_CLIENT_THROTTLED_DUE_TO_HEAVY_LOGGING__(firehose_buffer_t fb,
+		bool for_io, firehose_bank_state_u *state_out)
+{
+	firehose_client_send_push_and_wait(fb, for_io, state_out);
+}
+
+kern_return_t
+firehose_client_push_reply(mach_port_t req_port OS_UNUSED,
+	kern_return_t rtc, firehose_push_reply_t push_reply OS_UNUSED,
+	boolean_t quarantined OS_UNUSED)
+{
+	DISPATCH_INTERNAL_CRASH(rtc, "firehose_push_reply should never be sent "
+			"to the buffer receive port");
+}
+
+kern_return_t
+firehose_client_push_notify_async(mach_port_t server_port OS_UNUSED,
+	firehose_push_reply_t push_reply, boolean_t quarantined)
+{
+	dispatch_thread_context_t ctxt =
+			_dispatch_thread_context_find(_firehose_key);
+	firehose_buffer_t fb = ctxt->dtc_fb;
+	firehose_client_merge_updates(fb, true, push_reply, quarantined, NULL);
+	return KERN_SUCCESS;
+}
+
+#endif // !KERNEL
+#pragma mark -
+#pragma mark Buffer handling
+
+#ifndef KERNEL
+void
+firehose_buffer_update_limits(firehose_buffer_t fb)
+{
+	dispatch_unfair_lock_t fbb_lock = &fb->fb_header.fbh_bank.fbb_lock;
+	_dispatch_unfair_lock_lock(fbb_lock);
+	firehose_buffer_update_limits_unlocked(fb);
+	_dispatch_unfair_lock_unlock(fbb_lock);
+}
+#endif // !KERNEL
+
+OS_ALWAYS_INLINE
+static inline uint64_t
+firehose_buffer_chunk_apply_stamp_slop(uint64_t stamp)
+{
+	// <rdar://problem/23562733> boot starts mach absolute time at
+	// 0, and wrapping around to values above UINT64_MAX -
+	// FIREHOSE_STAMP_SLOP breaks firehose_buffer_stream_flush()
+	// assumptions
+	return stamp > FIREHOSE_STAMP_SLOP ? stamp - FIREHOSE_STAMP_SLOP : 0;
+}
+
+OS_ALWAYS_INLINE
+static inline bool
+firehose_buffer_chunk_stamp_delta_fits(firehose_chunk_t fc, uint64_t stamp)
+{
+	return !((stamp - fc->fc_timestamp) >> 48);
+}
+
+OS_ALWAYS_INLINE
+static inline firehose_tracepoint_t
+firehose_buffer_chunk_init(firehose_chunk_t fc,
+		firehose_tracepoint_query_t ask, uint8_t **privptr, uint64_t thread,
+		firehose_tracepoint_t *lft, uint64_t loss_start)
+{
+	firehose_tracepoint_t ft;
+	uint64_t stamp_and_len;
+
+	const uint16_t ft_size = offsetof(struct firehose_tracepoint_s, ft_data);
+
+	uint16_t pub_offs = offsetof(struct firehose_chunk_s, fc_data);
+	uint16_t priv_offs = FIREHOSE_CHUNK_SIZE;
+
+	if (unlikely(lft)) {
+		const uint16_t flp_size = sizeof(struct firehose_loss_payload_s);
+		uint64_t stamp, minstamp;
+		uint16_t flp_pub_offs;
+
+		// first, try to make both timestamps fit
+		minstamp = MIN(ask->stamp, loss_start);
+		fc->fc_timestamp =
+				firehose_buffer_chunk_apply_stamp_slop(minstamp);
+
+		// if they can't both fit, use the timestamp of the actual tracepoint:
+		//  a) this should _really_ never happen
+		//  b) if it does, a determined reader can tell that it did by comparing
+		//     the loss event start_stamp payload field with the main stamp
+		if (!firehose_buffer_chunk_stamp_delta_fits(fc, ask->stamp)) {
+			// if ask->stamp didn't fit on the first try it must be greater than
+			// loss_start by > 2^48, so it must also be greater than
+			// FIREHOSE_STAMP_SLOP - so no need to worry about underflow here
+			fc->fc_timestamp = ask->stamp - FIREHOSE_STAMP_SLOP;
+		}
+
+		*lft = (firehose_tracepoint_t)fc->fc_data;
+
+		stamp = firehose_buffer_chunk_stamp_delta_fits(fc, loss_start) ?
+				loss_start : ask->stamp;
+
+		stamp_and_len = stamp - fc->fc_timestamp;
+		stamp_and_len |= (uint64_t)flp_size << 48;
+		os_atomic_store(&(*lft)->ft_stamp_and_length, stamp_and_len, relaxed);
+
+		(*lft)->ft_thread = thread; // not really meaningful
+
+		flp_pub_offs = roundup(ft_size + flp_size, 8);
+		pub_offs += flp_pub_offs;
+		ft = (firehose_tracepoint_t)(fc->fc_data + flp_pub_offs);
+	} else {
+		fc->fc_timestamp =
+				firehose_buffer_chunk_apply_stamp_slop(ask->stamp);
+		ft = (firehose_tracepoint_t)fc->fc_data;
+	}
+
+	pub_offs += roundup(ft_size + ask->pubsize, 8);
+	priv_offs -= ask->privsize;
+
+	// Needed for process death handling (tracepoint-begin):
+	// write the length before making the chunk visible
+	stamp_and_len = ask->stamp - fc->fc_timestamp;
+	stamp_and_len |= (uint64_t)ask->pubsize << 48;
+	os_atomic_store(&ft->ft_stamp_and_length, stamp_and_len, relaxed);
+
+	ft->ft_thread = thread;
+
+	fc->fc_pos = (firehose_chunk_pos_u){
+		.fcp_next_entry_offs = pub_offs,
+		.fcp_private_offs = priv_offs,
+		.fcp_refcnt = 1,
+		.fcp_stream = ask->stream,
+		.fcp_flag_io = ask->for_io,
+		.fcp_quarantined = ask->quarantined,
+	};
+
+	if (privptr) {
+		*privptr = fc->fc_start + priv_offs;
+	}
+	return ft;
+}
+
+OS_NOINLINE
+static firehose_tracepoint_t
+firehose_buffer_stream_chunk_install(firehose_buffer_t fb,
+		firehose_tracepoint_query_t ask, uint8_t **privptr,
+		firehose_chunk_ref_t ref)
+{
+	firehose_stream_state_u state, new_state;
+	firehose_tracepoint_t ft = NULL, lft;
+	firehose_buffer_header_t fbh = &fb->fb_header;
+	firehose_buffer_stream_t fbs = &fbh->fbh_stream[ask->stream];
+
+	if (likely(ref)) {
+		uint64_t thread;
+		bool installed = false;
+		firehose_chunk_t fc = firehose_buffer_ref_to_chunk(fb, ref);
+
+		if (os_atomic_load(&fc->fc_pos.fcp_atomic_pos, relaxed)) {
+			// Needed for process death handling (recycle-reuse):
+			// No atomic fences required, we merely want to make sure the
+			// observers will see memory effects in program (asm) order.
+			// 1. the payload part of the chunk is cleared completely
+			// 2. the chunk is marked as reused
+			// This ensures that if we don't see a reference to a chunk in the
+			// ring and it is dirty, when crawling the chunk, we don't see
+			// remnants of other tracepoints.
+			//
+			// We only do that when the fc_pos is non zero, because zero means
+			// we just faulted the chunk, and the kernel already bzero-ed it.
+			bzero(fc->fc_data, sizeof(fc->fc_data));
+		}
+		dispatch_compiler_barrier();
+
+		if (ask->stream == firehose_stream_metadata) {
+			os_atomic_or(&fbh->fbh_bank.fbb_metadata_bitmap, 1ULL << ref,
+					relaxed);
+		}
+
+#if KERNEL
+		thread = thread_tid(current_thread());
+#else
+		thread = _pthread_threadid_self_np_direct();
+#endif
+
+		// If no tracepoints were lost at the tail end of this generation, the
+		// chunk timestamp is the stamp of the first tracepoint and the first
+		// tracepoint belongs at the beginning of the chunk.  If, however, we
+		// need to record a loss event, the timestamp has to be the minimum of
+		// the loss stamp and the stamp of the first tracepoint, and the loss
+		// event needs to be placed at the beginning of the chunk in addition to
+		// the first actual tracepoint.
+		state.fss_atomic_state =
+				os_atomic_load(&fbs->fbs_state.fss_atomic_state, relaxed);
+
+		if (likely(!state.fss_loss)) {
+			ft = firehose_buffer_chunk_init(fc, ask, privptr, thread, NULL, 0);
+
+			// release to publish the chunk init
+			installed = os_atomic_rmw_loop(&fbs->fbs_state.fss_atomic_state,
+					state.fss_atomic_state, new_state.fss_atomic_state, release, {
+				if (state.fss_loss) {
+					os_atomic_rmw_loop_give_up(break);
+				}
+				// clear the gate, waiter bits and loss count
+				new_state = (firehose_stream_state_u){
+					.fss_current = ref,
+					.fss_generation = state.fss_generation + 1,
+				};
+			});
+		}
+
+		if (unlikely(!installed)) {
+			uint64_t loss_start, loss_end;
+
+			// ensure we can see the start stamp
+			(void)os_atomic_load(&fbs->fbs_state.fss_atomic_state, acquire);
+			loss_start = fbs->fbs_loss_start;
+			fbs->fbs_loss_start = 0; // reset under fss_gate
+			loss_end = mach_continuous_time();
+
+			ft = firehose_buffer_chunk_init(fc, ask, privptr, thread, &lft,
+					loss_start);
+			os_atomic_rmw_loop(&fbs->fbs_state.fss_atomic_state,
+					state.fss_atomic_state, new_state.fss_atomic_state, release, {
+				// no giving up this time!
+				new_state = (firehose_stream_state_u){
+					.fss_current = ref,
+					.fss_generation = state.fss_generation + 1,
+				};
+			});
+
+			struct firehose_loss_payload_s flp = {
+				.start_stamp = loss_start,
+				.end_stamp = loss_end,
+				.count = state.fss_loss,
+			};
+			memcpy(lft->ft_data, &flp, sizeof(flp));
+
+			firehose_tracepoint_id_u ftid = { .ftid = {
+				._namespace = firehose_tracepoint_namespace_loss,
+				// no meaningful value for _type
+				// nor for _flags
+				._code = ask->stream,
+			} };
+
+			// publish the contents of the loss tracepoint
+			os_atomic_store(&lft->ft_id.ftid_atomic_value, ftid.ftid_value,
+					release);
+		}
+	} else {
+		// the allocator gave up - just clear the allocator and waiter bits and
+		// increment the loss count
+		state.fss_atomic_state =
+				os_atomic_load(&fbs->fbs_state.fss_atomic_state, relaxed);
+		if (!state.fss_timestamped) {
+			fbs->fbs_loss_start = mach_continuous_time();
+
+			// release to publish the timestamp
+			os_atomic_rmw_loop(&fbs->fbs_state.fss_atomic_state,
+					state.fss_atomic_state, new_state.fss_atomic_state,
+					release, {
+				new_state = (firehose_stream_state_u){
+					.fss_loss =
+							MIN(state.fss_loss + 1, FIREHOSE_LOSS_COUNT_MAX),
+					.fss_timestamped = true,
+					.fss_generation = state.fss_generation,
+				};
+			});
+		} else {
+			os_atomic_rmw_loop(&fbs->fbs_state.fss_atomic_state,
+					state.fss_atomic_state, new_state.fss_atomic_state,
+					relaxed, {
+				new_state = (firehose_stream_state_u){
+					.fss_loss =
+							MIN(state.fss_loss + 1, FIREHOSE_LOSS_COUNT_MAX),
+					.fss_timestamped = true,
+					.fss_generation = state.fss_generation,
+				};
+			});
+		}
+	}
+
+	// pairs with the one in firehose_buffer_tracepoint_reserve()
+	__firehose_critical_region_leave();
+
+#ifndef KERNEL
+	_dispatch_trace_firehose_chunk_install(((uint64_t *)ask)[0],
+			((uint64_t *)ask)[1], state.fss_atomic_state,
+			new_state.fss_atomic_state);
+	if (unlikely(state.fss_allocator & FIREHOSE_GATE_WAITERS_MASK)) {
+		_dispatch_gate_broadcast_slow(&fbs->fbs_state.fss_gate,
+				state.fss_gate.dgl_lock);
+	}
+
+	if (unlikely(state.fss_current == FIREHOSE_STREAM_STATE_PRISTINE)) {
+		firehose_buffer_update_limits(fb);
+	}
+
+	if (unlikely(os_atomic_load(&fbh->fbh_quarantined_state, relaxed) ==
+			FBH_QUARANTINE_PENDING)) {
+		if (os_atomic_cmpxchg(&fbh->fbh_quarantined_state,
+				FBH_QUARANTINE_PENDING, FBH_QUARANTINE_STARTED, relaxed)) {
+			firehose_client_start_quarantine(fb);
+		}
+	}
+#endif // !KERNEL
+
+	return ft;
+}
+
+#ifndef KERNEL
+OS_ALWAYS_INLINE
+static inline firehose_chunk_ref_t
+firehose_buffer_ring_try_grow(firehose_buffer_bank_t fbb, uint16_t limit)
+{
+	firehose_chunk_ref_t ref = 0;
+	uint64_t bitmap;
+
+	_dispatch_unfair_lock_lock(&fbb->fbb_lock);
+	bitmap = ~(fbb->fbb_bitmap | (~0ULL << limit));
+	if (bitmap) {
+		ref = firehose_bitmap_first_set(bitmap);
+		fbb->fbb_bitmap |= 1U << ref;
+	}
+	_dispatch_unfair_lock_unlock(&fbb->fbb_lock);
+	return ref;
+}
+
+OS_ALWAYS_INLINE
+static inline firehose_chunk_ref_t
+firehose_buffer_ring_shrink(firehose_buffer_t fb, firehose_chunk_ref_t ref)
+{
+	const size_t madv_size =
+			FIREHOSE_CHUNK_SIZE * FIREHOSE_BUFFER_MADVISE_CHUNK_COUNT;
+	const size_t madv_mask =
+			(1ULL << FIREHOSE_BUFFER_MADVISE_CHUNK_COUNT) - 1;
+
+	dispatch_unfair_lock_t fbb_lock = &fb->fb_header.fbh_bank.fbb_lock;
+	uint64_t bitmap;
+
+	_dispatch_unfair_lock_lock(fbb_lock);
+	if (ref < fb->fb_header.fbh_bank.fbb_limits.fbs_max_ref) {
+		goto done;
+	}
+
+	bitmap = (fb->fb_header.fbh_bank.fbb_bitmap &= ~(1UL << ref));
+	ref &= ~(FIREHOSE_BUFFER_MADVISE_CHUNK_COUNT - 1);
+	if ((bitmap & (madv_mask << ref)) == 0) {
+		// if MADVISE_WIDTH consecutive chunks are free, madvise them free
+		madvise(firehose_buffer_ref_to_chunk(fb, ref), madv_size, MADV_FREE);
+	}
+	ref = 0;
+done:
+	_dispatch_unfair_lock_unlock(fbb_lock);
+	return ref;
+}
+#endif // !KERNEL
+
+OS_NOINLINE
+void
+firehose_buffer_ring_enqueue(firehose_buffer_t fb, firehose_chunk_ref_t ref)
+{
+	firehose_chunk_t fc = firehose_buffer_ref_to_chunk(fb, ref);
+	uint16_t volatile *fbh_ring;
+	uint16_t volatile *fbh_ring_head;
+	uint16_t head, gen, dummy, idx;
+	firehose_chunk_pos_u fc_pos = fc->fc_pos;
+	bool for_io = fc_pos.fcp_flag_io;
+
+	if (for_io) {
+		fbh_ring = fb->fb_header.fbh_io_ring;
+		fbh_ring_head = &fb->fb_header.fbh_ring_io_head;
+	} else {
+		fbh_ring = fb->fb_header.fbh_mem_ring;
+		fbh_ring_head = &fb->fb_header.fbh_ring_mem_head;
+	}
+
+#ifdef KERNEL
+	// The algorithm in the kernel is simpler:
+	//  1. reserve a write position for the head
+	//  2. store the new reference at that position
+	// Enqueuers can't starve each other that way.
+	//
+	// However, the dequeuers now have to sometimes wait for the value written
+	// in the ring to appear and have to spin, which is okay since the kernel
+	// disables preemption around these two consecutive atomic operations.
+	// See firehose_client_drain.
+	__firehose_critical_region_enter();
+	head = os_atomic_inc_orig(fbh_ring_head, relaxed);
+	gen = head & FIREHOSE_RING_POS_GEN_MASK;
+	idx = head & FIREHOSE_RING_POS_IDX_MASK;
+
+	while (unlikely(!os_atomic_cmpxchgv(&fbh_ring[idx], gen, gen | ref, &dummy,
+			relaxed))) {
+		// can only ever happen if a recycler is slow, this requires having
+		// enough cores (>5 for I/O e.g.)
+		_dispatch_wait_until(fbh_ring[idx] == gen);
+	}
+	__firehose_critical_region_leave();
+	__firehose_buffer_push_to_logd(fb, for_io);
+#else
+	// The algorithm is:
+	//   1. read the head position
+	//   2. cmpxchg head.gen with the (head.gen | ref) at head.idx
+	//   3. if it fails wait until either the head cursor moves,
+	//      or the cell becomes free
+	//
+	// The most likely stall at (3) is because another enqueuer raced us
+	// and made the cell non empty.
+	//
+	// The alternative is to reserve the enqueue slot with an atomic inc.
+	// Then write the ref into the ring. This would be much simpler as the
+	// generation packing wouldn't be required (though setting the ring cell
+	// would still need a cmpxchg loop to avoid clobbering values of slow
+	// dequeuers)
+	//
+	// But then that means that flushers (logd) could be starved until that
+	// finishes, and logd cannot be held forever (that could even be a logd
+	// DoS from malicious programs). Meaning that logd would stop draining
+	// buffer queues when encountering that issue, leading the program to be
+	// stuck in firehose_client_push() apparently waiting on logd, while
+	// really it's waiting on itself. It's better for the scheduler if we
+	// make it clear that we're waiting on ourselves!
+
+	head = os_atomic_load(fbh_ring_head, relaxed);
+	for (;;) {
+		gen = head & FIREHOSE_RING_POS_GEN_MASK;
+		idx = head & FIREHOSE_RING_POS_IDX_MASK;
+
+		// a thread being preempted here for GEN_MASK worth of ring rotations,
+		// it could lead to the cmpxchg succeed, and have a bogus enqueue
+		// (confused enqueuer)
+		if (likely(os_atomic_cmpxchgv(&fbh_ring[idx], gen, gen | ref, &dummy,
+				relaxed))) {
+			if (likely(os_atomic_cmpxchgv(fbh_ring_head, head, head + 1,
+					&head, release))) {
+				__firehose_critical_region_leave();
+				break;
+			}
+			// this thread is a confused enqueuer, need to undo enqueue
+			os_atomic_store(&fbh_ring[idx], gen, relaxed);
+			continue;
+		}
+
+		_dispatch_wait_until(({
+			// wait until either the head moves (another enqueuer is done)
+			// or (not very likely) a recycler is very slow
+			// or (very unlikely) the confused thread undoes its enqueue
+			uint16_t old_head = head;
+			head = *fbh_ring_head;
+			head != old_head || fbh_ring[idx] == gen;
+		}));
+	}
+
+	pthread_priority_t pp = fc_pos.fcp_qos;
+	pp <<= _PTHREAD_PRIORITY_QOS_CLASS_SHIFT;
+	firehose_client_send_push_async(fb, _pthread_qos_class_decode(pp, NULL, NULL),
+			for_io);
+#endif
+}
+
+#ifndef KERNEL
+void
+firehose_buffer_force_connect(firehose_buffer_t fb)
+{
+	mach_port_t sendp = fb->fb_header.fbh_sendp[FIREHOSE_BUFFER_PUSHPORT_MEM];
+	if (sendp == MACH_PORT_NULL) {
+		firehose_client_reconnect(fb, MACH_PORT_NULL,
+				FIREHOSE_BUFFER_PUSHPORT_MEM);
+	}
+}
+#endif
+
+OS_ALWAYS_INLINE
+static inline firehose_chunk_ref_t
+firehose_buffer_ring_try_recycle(firehose_buffer_t fb)
+{
+	firehose_ring_tail_u pos, old;
+	uint16_t volatile *fbh_ring;
+	uint16_t gen, entry, tail;
+	firehose_chunk_ref_t ref;
+	firehose_chunk_t fc;
+	bool for_io;
+
+	os_atomic_rmw_loop(&fb->fb_header.fbh_ring_tail.frp_atomic_tail,
+			old.frp_atomic_tail, pos.frp_atomic_tail, relaxed, {
+		pos = old;
+		if (likely(old.frp_mem_tail != old.frp_mem_flushed)) {
+			pos.frp_mem_tail++;
+		} else if (likely(old.frp_io_tail != old.frp_io_flushed)) {
+			pos.frp_io_tail++;
+		} else {
+			os_atomic_rmw_loop_give_up(return 0);
+		}
+	});
+
+	// there's virtually no chance that the lack of acquire barrier above
+	// lets us read a value from the ring so stale that it's still an Empty
+	// marker. For correctness purposes have a cheap loop that should never
+	// really loop, instead of an acquire barrier in the cmpxchg above.
+	for_io = (pos.frp_io_tail != old.frp_io_tail);
+	if (for_io) {
+		fbh_ring = fb->fb_header.fbh_io_ring;
+		tail = old.frp_io_tail & FIREHOSE_RING_POS_IDX_MASK;
+	} else {
+		fbh_ring = fb->fb_header.fbh_mem_ring;
+		tail = old.frp_mem_tail & FIREHOSE_RING_POS_IDX_MASK;
+	}
+	_dispatch_wait_until((entry = fbh_ring[tail]) & FIREHOSE_RING_POS_IDX_MASK);
+
+	// Needed for process death handling (recycle-dequeue):
+	// No atomic fences required, we merely want to make sure the observers
+	// will see memory effects in program (asm) order.
+	// 1. the chunk is marked as "void&full" (clobbering the pos with FULL_BIT)
+	// 2. then we remove any reference to the chunk from the ring
+	// This ensures that if we don't see a reference to a chunk in the ring
+	// and it is dirty, it is a chunk being written to that needs a flush
+	gen = (entry & FIREHOSE_RING_POS_GEN_MASK) + FIREHOSE_RING_POS_GEN_INC;
+	ref = entry & FIREHOSE_RING_POS_IDX_MASK;
+	fc = firehose_buffer_ref_to_chunk(fb, ref);
+
+	if (!for_io && fc->fc_pos.fcp_stream == firehose_stream_metadata) {
+		os_atomic_and(&fb->fb_header.fbh_bank.fbb_metadata_bitmap,
+				~(1ULL << ref), relaxed);
+	}
+	os_atomic_store(&fc->fc_pos.fcp_atomic_pos,
+			FIREHOSE_CHUNK_POS_FULL_BIT, relaxed);
+	dispatch_compiler_barrier();
+	os_atomic_store(&fbh_ring[tail], gen, relaxed);
+	return ref;
+}
+
+#ifndef KERNEL
+OS_NOINLINE
+static firehose_tracepoint_t
+firehose_buffer_tracepoint_reserve_wait_for_chunks_from_logd(firehose_buffer_t fb,
+		firehose_tracepoint_query_t ask, uint8_t **privptr)
+{
+	bool for_io = ask->for_io;
+	firehose_buffer_pushport_t pushport = for_io;
+	firehose_buffer_bank_t const fbb = &fb->fb_header.fbh_bank;
+	firehose_bank_state_u state;
+	firehose_chunk_ref_t ref, fbs_max_ref;
+
+	for (int i = MACH_PORT_QLIMIT_BASIC;
+			i-- && firehose_drain_notifications_once(fb); );
+
+	// first wait for our bank to have space, if needed
+	if (unlikely(!ask->is_bank_ok)) {
+		state.fbs_atomic_state =
+				os_atomic_load(&fbb->fbb_state.fbs_atomic_state, relaxed);
+		while (!firehose_buffer_bank_try_reserve_slot(fb, for_io, &state)) {
+			if (ask->quarantined) {
+				__FIREHOSE_CLIENT_THROTTLED_DUE_TO_HEAVY_LOGGING__(fb, for_io,
+						&state);
+			} else {
+				firehose_client_send_push_and_wait(fb, for_io, &state);
+			}
+			if (unlikely(fb->fb_header.fbh_sendp[pushport] == MACH_PORT_DEAD)) {
+				// logd was unloaded, give up
+				return NULL;
+			}
+		}
+		fbs_max_ref = state.fbs_max_ref;
+	} else {
+		fbs_max_ref = fbb->fbb_state.fbs_max_ref;
+	}
+
+	// third, wait for a chunk to come up, and if not, wait on the daemon
+	for (;;) {
+		if (likely(ref = firehose_buffer_ring_try_recycle(fb))) {
+			if (unlikely(ref >= fbs_max_ref)) {
+				ref = firehose_buffer_ring_shrink(fb, ref);
+				if (!ref) {
+					continue;
+				}
+			}
+			break;
+		}
+		if (likely(ref = firehose_buffer_ring_try_grow(fbb, fbs_max_ref))) {
+			break;
+		}
+		if (ask->quarantined) {
+			__FIREHOSE_CLIENT_THROTTLED_DUE_TO_HEAVY_LOGGING__(fb, for_io,
+					NULL);
+		} else {
+			firehose_client_send_push_and_wait(fb, for_io, NULL);
+		}
+		if (unlikely(fb->fb_header.fbh_sendp[pushport] == MACH_PORT_DEAD)) {
+			// logd was unloaded, give up
+			break;
+		}
+	}
+
+	return firehose_buffer_stream_chunk_install(fb, ask, privptr, ref);
+}
+#else
+static inline dispatch_lock
+_dispatch_gate_lock_load_seq_cst(dispatch_gate_t l)
+{
+	return os_atomic_load(&l->dgl_lock, seq_cst);
+}
+OS_NOINLINE
+static void
+_dispatch_firehose_gate_wait(dispatch_gate_t l, uint32_t flags)
+{
+	(void)flags;
+	_dispatch_wait_until(_dispatch_gate_lock_load_seq_cst(l) == 0);
+}
+#endif // KERNEL
+
+firehose_tracepoint_t
+firehose_buffer_tracepoint_reserve_slow(firehose_buffer_t fb,
+		firehose_tracepoint_query_t ask, uint8_t **privptr)
+{
+	const unsigned for_io = ask->for_io;
+	const firehose_buffer_bank_t fbb = &fb->fb_header.fbh_bank;
+	firehose_bank_state_u state;
+	bool reserved;
+	firehose_chunk_ref_t ref = 0;
+
+#ifndef KERNEL
+	// before we try to allocate anything look at whether there are things logd
+	// already sent back to us
+	firehose_drain_notifications_once(fb);
+#endif // KERNEL
+
+	state.fbs_atomic_state =
+			os_atomic_load(&fbb->fbb_state.fbs_atomic_state, relaxed);
+	reserved = firehose_buffer_bank_try_reserve_slot(fb, for_io, &state);
+
+#ifndef KERNEL
+	if (likely(reserved)) {
+		while (!ref) {
+			ref = firehose_buffer_ring_try_recycle(fb);
+			if (unlikely(!ref)) {
+				break;
+			}
+
+			if (unlikely(ref >= state.fbs_max_ref)) {
+				ref = firehose_buffer_ring_shrink(fb, ref);
+			}
+		}
+
+		if (unlikely(!ref)) {
+			ref = firehose_buffer_ring_try_grow(fbb, state.fbs_max_ref);
+		}
+	}
+
+	if (likely(ref || !ask->reliable)) {
+		if (!ref && reserved) {
+			firehose_buffer_bank_relinquish_slot(fb, for_io);
+		}
+
+		// installing `0` unlocks the allocator
+		return firehose_buffer_stream_chunk_install(fb, ask, privptr, ref);
+	} else {
+		firehose_buffer_stream_signal_waiting_for_logd(fb, ask->stream);
+
+		ask->is_bank_ok = reserved;
+		return firehose_buffer_tracepoint_reserve_wait_for_chunks_from_logd(fb,
+				ask, privptr);
+	}
+#else
+	if (likely(reserved)) {
+		ref = firehose_buffer_ring_try_recycle(fb);
+		if (unlikely(ref == 0)) {
+			// the kernel has no overlap between I/O and memory chunks, so
+			// having an available bank slot means we must be able to recycle
+			DISPATCH_INTERNAL_CRASH(0, "Unable to recycle a chunk");
+		}
+	}
+	return firehose_buffer_stream_chunk_install(fb, ask, privptr, ref);
+#endif // KERNEL
+}
+
+#ifdef KERNEL
+firehose_tracepoint_t
+__firehose_buffer_tracepoint_reserve(uint64_t stamp, firehose_stream_t stream,
+		uint16_t pubsize, uint16_t privsize, uint8_t **privptr)
+{
+	firehose_buffer_t fb = kernel_firehose_buffer;
+	if (unlikely(!fb)) {
+		return NULL;
+	}
+	return firehose_buffer_tracepoint_reserve(fb, stamp, stream, pubsize,
+			privsize, privptr, false);
+}
+
+firehose_buffer_t
+__firehose_buffer_create(size_t *size)
+{
+	if (!kernel_firehose_buffer) {
+		kernel_firehose_buffer = firehose_buffer_create(MACH_PORT_NULL, 0, 0);
+	}
+
+	if (size) {
+		*size = FIREHOSE_BUFFER_KERNEL_CHUNK_COUNT * FIREHOSE_CHUNK_SIZE;
+	}
+	return kernel_firehose_buffer;
+}
+
+void
+__firehose_buffer_tracepoint_flush(firehose_tracepoint_t ft,
+		firehose_tracepoint_id_u ftid)
+{
+	return firehose_buffer_tracepoint_flush(kernel_firehose_buffer, ft, ftid);
+}
+
+bool
+__firehose_merge_updates(firehose_push_reply_t update)
+{
+	firehose_buffer_t fb = kernel_firehose_buffer;
+	bool has_more = false;
+	uint16_t head;
+
+	if (likely(fb)) {
+		firehose_buffer_header_t fbh = &fb->fb_header;
+		firehose_client_merge_updates(fb, true, update, false, NULL);
+		head = os_atomic_load(&fbh->fbh_ring_io_head, relaxed);
+		if (head != (uint16_t)os_atomic_load(&fbh->fbh_bank.fbb_io_flushed, relaxed)) {
+			has_more = true;
+		}
+		head = os_atomic_load(&fbh->fbh_ring_mem_head, relaxed);
+		if (head != (uint16_t)os_atomic_load(&fbh->fbh_bank.fbb_mem_flushed, relaxed)) {
+			has_more = true;
+		}
+	}
+	return has_more;
+}
+
+int
+__firehose_kernel_configuration_valid(uint8_t chunk_count, uint8_t io_pages)
+{
+	return (((chunk_count % 4) == 0) &&
+			(chunk_count >= FIREHOSE_BUFFER_KERNEL_MIN_CHUNK_COUNT) &&
+			(chunk_count <= FIREHOSE_BUFFER_KERNEL_MAX_CHUNK_COUNT) &&
+			(io_pages <= (chunk_count * 3 / 4)));
+}
+#endif // KERNEL
+
+#endif // OS_FIREHOSE_SPI

--- a/src/Kernel/libfirehose_kernel/src/firehose_buffer_internal.h
+++ b/src/Kernel/libfirehose_kernel/src/firehose_buffer_internal.h
@@ -1,0 +1,260 @@
+/*
+ * Copyright (c) 2015 Apple Inc. All rights reserved.
+ *
+ * @APPLE_APACHE_LICENSE_HEADER_START@
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @APPLE_APACHE_LICENSE_HEADER_END@
+ */
+
+#ifndef __FIREHOSE_BUFFER_INTERNAL__
+#define __FIREHOSE_BUFFER_INTERNAL__
+
+#if BYTE_ORDER != LITTLE_ENDIAN
+#error unsupported byte order
+#endif
+
+#ifndef KERNEL
+#include <os/lock_private.h>
+#endif
+
+// firehose buffer is CHUNK_COUNT * CHUNK_SIZE big == 256k
+#define FIREHOSE_BUFFER_CHUNK_COUNT					64ul
+#ifndef KERNEL
+#define FIREHOSE_BUFFER_CHUNK_PREALLOCATED_COUNT	4
+#define FIREHOSE_BUFFER_MADVISE_CHUNK_COUNT			4
+#endif
+
+#define FIREHOSE_RING_POS_GEN_INC		((uint16_t)(FIREHOSE_BUFFER_CHUNK_COUNT))
+#define FIREHOSE_RING_POS_IDX_MASK		((uint16_t)(FIREHOSE_RING_POS_GEN_INC - 1))
+#define FIREHOSE_RING_POS_GEN_MASK		((uint16_t)~FIREHOSE_RING_POS_IDX_MASK)
+
+#if __has_feature(c_static_assert)
+_Static_assert(FIREHOSE_RING_POS_IDX_MASK < 0xff,
+		"firehose chunk ref fits in its type with space for PRISTINE");
+#endif
+
+typedef uint8_t firehose_chunk_ref_t;
+
+static const unsigned long firehose_stream_uses_io_bank =
+	(1UL << firehose_stream_persist) |
+	(1UL << firehose_stream_special) |
+	(1UL << firehose_stream_signpost);
+
+typedef union {
+#define FIREHOSE_BANK_SHIFT(bank)			(16 * (bank))
+#define FIREHOSE_BANK_INC(bank)				(1ULL << FIREHOSE_BANK_SHIFT(bank))
+	uint64_t fbs_atomic_state;
+	struct {
+		union {
+			struct {
+				uint16_t fbs_mem_bank;
+				uint16_t fbs_io_bank;
+			};
+			uint16_t fbs_banks[2];
+		};
+		firehose_chunk_ref_t fbs_max_ref;
+		uint8_t fbs_unused1;
+		uint16_t fbs_unused2;
+	};
+} firehose_bank_state_u;
+
+#if __has_feature(c_static_assert)
+_Static_assert(8 * offsetof(firehose_bank_state_u, fbs_mem_bank)
+		== FIREHOSE_BANK_SHIFT(0), "mem bank shift");
+_Static_assert(8 * offsetof(firehose_bank_state_u, fbs_io_bank)
+		== FIREHOSE_BANK_SHIFT(1), "mem bank shift");
+#endif
+
+typedef struct firehose_buffer_bank_s {
+	firehose_bank_state_u volatile fbb_state;
+	uint64_t volatile fbb_metadata_bitmap;
+	uint64_t volatile fbb_mem_flushed;
+	uint64_t volatile fbb_mem_notifs;
+	uint64_t volatile fbb_mem_sync_pushes;
+	uint64_t volatile fbb_io_flushed;
+	uint64_t volatile fbb_io_notifs;
+	uint64_t volatile fbb_io_sync_pushes;
+#define FIREHOSE_BUFFER_BANK_FLAG_LOW_MEMORY	(1UL << 0)
+#define FIREHOSE_BUFFER_BANK_FLAG_HIGH_RATE		(1UL << 1)
+	unsigned long volatile fbb_flags;
+
+	uint64_t fbb_bitmap; // protected by fbb_lock
+	firehose_bank_state_u fbb_limits; // protected by fbb_lock
+#ifdef KERNEL
+	uint32_t _fbb_unused;
+#else
+	dispatch_unfair_lock_s fbb_lock;
+#endif
+} OS_ALIGNED(64) *firehose_buffer_bank_t;
+
+typedef union {
+	uint64_t fss_atomic_state;
+	dispatch_gate_s fss_gate;
+	struct {
+#define FIREHOSE_GATE_RELIABLE_WAITERS_BIT 		0x00000001UL
+#define FIREHOSE_GATE_UNRELIABLE_WAITERS_BIT 	0x00000002UL
+#define FIREHOSE_GATE_WAITERS_MASK 				0x00000003UL
+		uint32_t fss_allocator;
+#define FIREHOSE_STREAM_STATE_PRISTINE		0xff
+		firehose_chunk_ref_t fss_current;
+		uint8_t fss_loss : FIREHOSE_LOSS_COUNT_WIDTH;
+		uint8_t fss_timestamped : 1;
+		uint8_t fss_waiting_for_logd : 1;
+
+		/*
+		 * We use a generation counter to prevent a theoretical ABA problem: a
+		 * thread could try to acquire a tracepoint in a chunk, fail to do so,
+		 * mark it as to be pushed, enqueue it, and then be preempted.  It
+		 * sleeps for a long time, and then tries to acquire the allocator bit
+		 * and uninstall the chunk. Succeeds in doing so, but because the chunk
+		 * actually happened to have cycled all the way back to being installed.
+		 * That thread would effectively hide that unflushed chunk and leak it.
+		 * Having a generation counter prevents the uninstallation of the chunk
+		 * to spuriously succeed when it was a re-incarnation of it.
+		 */
+		uint16_t fss_generation;
+	};
+} firehose_stream_state_u;
+
+typedef struct firehose_buffer_stream_s {
+	firehose_stream_state_u fbs_state;
+	uint64_t fbs_loss_start; // protected by fss_gate
+} OS_ALIGNED(128) *firehose_buffer_stream_t;
+
+typedef union {
+	uint64_t frp_atomic_tail;
+	struct {
+		uint16_t frp_mem_tail;
+		uint16_t frp_mem_flushed;
+		uint16_t frp_io_tail;
+		uint16_t frp_io_flushed;
+	};
+} firehose_ring_tail_u;
+
+OS_ENUM(firehose_buffer_pushport, uint8_t,
+	FIREHOSE_BUFFER_PUSHPORT_MEM,
+	FIREHOSE_BUFFER_PUSHPORT_IO,
+	FIREHOSE_BUFFER_NPUSHPORTS,
+);
+
+/*
+ * Rings are circular buffers with CHUNK_COUNT entries, with 3 important markers
+ *
+ * +--------+-------------------------+------------+---------------------------+
+ * |xxxxxxxx|                         |............|xxxxxxxxxxxxxxxxxxxxxxxxxxx|
+ * +--------+-------------------------+------------+---------------------------+
+ *          ^                         ^            ^
+ *        head                       tail       flushed
+ *
+ * A ring position is a uint16_t made of a generation (see GEN_MASK) and an
+ * index (see IDX_MASK). Slots of that ring hold tagged page references. These
+ * are made from a generation (see GEN_MASK) and a page reference.
+ *
+ * A generation is how many times the head wrapped around.
+ *
+ * These conditions hold:
+ *   (uint16_t)(flushed - tail) < FIREHOSE_BUFFER_CHUNK_COUNT
+ *   (uint16_t)(head - flushed) < FIREHOSE_BUFFER_CHUNK_COUNT
+ * which really means, on the circular buffer, tail <= flushed <= head.
+ *
+ * Page references span from 1 to (CHUNK_COUNT - 1). 0 is an invalid page
+ * (corresponds to the buffer header) and means "unused".
+ *
+ *
+ * - Entries situated between tail and flushed hold references to pages that
+ *   the firehose consumer (logd) has flushed, and can be reused.
+ *
+ * - Entries situated between flushed and head are references to pages waiting
+ *   to be flushed.
+ *
+ * - Entries not situated between tail and head are either slots being modified
+ *   or that should be set to Empty. Empty is the 0 page reference associated
+ *   with the generation count the head will have the next time it will go over
+ *   that slot.
+ */
+typedef struct firehose_buffer_header_s {
+	uint16_t volatile				fbh_mem_ring[FIREHOSE_BUFFER_CHUNK_COUNT];
+	uint16_t volatile				fbh_io_ring[FIREHOSE_BUFFER_CHUNK_COUNT];
+
+	firehose_ring_tail_u volatile	fbh_ring_tail OS_ALIGNED(64);
+	uint32_t						fbh_spi_version;
+	uint16_t volatile				fbh_ring_mem_head OS_ALIGNED(64);
+	uint16_t volatile				fbh_ring_io_head OS_ALIGNED(64);
+	struct firehose_buffer_bank_s	fbh_bank;
+	struct firehose_buffer_stream_s fbh_stream[_firehose_stream_max];
+
+	uint64_t						fbh_uniquepid;
+	pid_t							fbh_pid;
+	mach_port_t						fbh_logd_port;
+	mach_port_t volatile			fbh_sendp[FIREHOSE_BUFFER_NPUSHPORTS];
+	mach_port_t						fbh_recvp;
+
+	// past that point fields may be aligned differently between 32 and 64bits
+#ifndef KERNEL
+	dispatch_unfair_lock_s			fbh_logd_lock;
+#define FBH_QUARANTINE_NONE		0
+#define FBH_QUARANTINE_PENDING	1
+#define FBH_QUARANTINE_STARTED	2
+	uint8_t volatile				fbh_quarantined_state;
+	bool							fbh_quarantined;
+#endif
+	uint64_t						fbh_unused[0];
+} OS_ALIGNED(FIREHOSE_CHUNK_SIZE) *firehose_buffer_header_t;
+
+union firehose_buffer_u {
+	struct firehose_buffer_header_s fb_header;
+	struct firehose_chunk_s fb_chunks[FIREHOSE_BUFFER_CHUNK_COUNT];
+};
+
+// used to let the compiler pack these values in 1 or 2 registers
+typedef struct firehose_tracepoint_query_s {
+	uint64_t stamp;
+	uint16_t pubsize;
+	uint16_t privsize;
+	firehose_stream_t stream;
+	bool	 is_bank_ok;
+	bool	 for_io : 1;
+	bool	 quarantined : 1;
+	bool	 reliable : 1;
+} *firehose_tracepoint_query_t;
+
+#ifndef FIREHOSE_SERVER
+
+firehose_buffer_t
+firehose_buffer_create(mach_port_t logd_port, uint64_t unique_pid,
+		unsigned long bank_flags);
+
+firehose_tracepoint_t
+firehose_buffer_tracepoint_reserve_slow(firehose_buffer_t fb,
+		firehose_tracepoint_query_t ask, uint8_t **privptr);
+
+void *
+firehose_buffer_get_logging_prefs(firehose_buffer_t fb, size_t *size);
+
+bool
+firehose_buffer_should_send_strings(firehose_buffer_t fb);
+
+void
+firehose_buffer_update_limits(firehose_buffer_t fb);
+
+void
+firehose_buffer_ring_enqueue(firehose_buffer_t fb, firehose_chunk_ref_t ref);
+
+void
+firehose_buffer_force_connect(firehose_buffer_t fb);
+
+#endif
+
+#endif // __FIREHOSE_BUFFER_INTERNAL__

--- a/src/Kernel/libfirehose_kernel/src/firehose_inline_internal.h
+++ b/src/Kernel/libfirehose_kernel/src/firehose_inline_internal.h
@@ -1,0 +1,547 @@
+/*
+ * Copyright (c) 2015 Apple Inc. All rights reserved.
+ *
+ * @APPLE_APACHE_LICENSE_HEADER_START@
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @APPLE_APACHE_LICENSE_HEADER_END@
+ */
+
+#ifndef __FIREHOSE_INLINE_INTERNAL__
+#define __FIREHOSE_INLINE_INTERNAL__
+
+#ifndef _os_atomic_basetypeof
+#define _os_atomic_basetypeof(p) \
+		__typeof__(atomic_load_explicit(_os_atomic_c11_atomic(p), memory_order_relaxed))
+#endif
+
+#define firehose_atomic_maxv(p, v, o, m) \
+		os_atomic_rmw_loop(p, *(o), (v), m, { \
+			if (*(o) >= (v)) os_atomic_rmw_loop_give_up(break); \
+		})
+
+#define firehose_atomic_max(p, v, m)   ({ \
+		_os_atomic_basetypeof(p) _old; \
+		firehose_atomic_maxv(p, v, &_old, m); \
+	})
+
+#ifndef KERNEL
+// caller must test for non zero first
+OS_ALWAYS_INLINE
+static inline firehose_chunk_ref_t
+firehose_bitmap_first_set(uint64_t bitmap)
+{
+	dispatch_assert(bitmap != 0);
+	// this builtin returns 0 if bitmap is 0, or (first bit set + 1)
+	return (firehose_chunk_ref_t)__builtin_ffsll((long long)bitmap) - 1;
+}
+#endif
+
+#pragma mark -
+#pragma mark Mach Misc.
+#ifndef KERNEL
+
+OS_ALWAYS_INLINE
+static inline mach_port_t
+firehose_mach_port_allocate(uint32_t flags, mach_port_msgcount_t qlimit,
+		void *ctx)
+{
+	mach_port_t port = MACH_PORT_NULL;
+	mach_port_options_t opts = {
+		.flags = flags | MPO_QLIMIT,
+		.mpl = { .mpl_qlimit = qlimit },
+	};
+	kern_return_t kr = mach_port_construct(mach_task_self(), &opts,
+			(mach_port_context_t)ctx, &port);
+	if (unlikely(kr)) {
+		DISPATCH_VERIFY_MIG(kr);
+		DISPATCH_CLIENT_CRASH(kr, "Unable to allocate mach port");
+	}
+	return port;
+}
+
+OS_ALWAYS_INLINE
+static inline kern_return_t
+firehose_mach_port_recv_dispose(mach_port_t port, void *ctx)
+{
+	kern_return_t kr;
+	kr = mach_port_destruct(mach_task_self(), port, 0,
+			(mach_port_context_t)ctx);
+	DISPATCH_VERIFY_MIG(kr);
+	return kr;
+}
+
+OS_ALWAYS_INLINE
+static inline void
+firehose_mach_port_send_release(mach_port_t port)
+{
+	kern_return_t kr = mach_port_deallocate(mach_task_self(), port);
+	DISPATCH_VERIFY_MIG(kr);
+	dispatch_assume_zero(kr);
+}
+
+OS_ALWAYS_INLINE
+static inline void
+firehose_mach_port_guard(mach_port_t port, bool strict, void *ctx)
+{
+	kern_return_t kr = mach_port_guard(mach_task_self(), port,
+			(mach_port_context_t)ctx, strict);
+	DISPATCH_VERIFY_MIG(kr);
+	dispatch_assume_zero(kr);
+}
+
+OS_ALWAYS_INLINE
+static inline void
+firehose_mig_server(dispatch_mig_callback_t demux, size_t maxmsgsz,
+		mach_msg_header_t *hdr)
+{
+	mig_reply_error_t *msg_reply = (mig_reply_error_t *)alloca(maxmsgsz);
+	kern_return_t rc = KERN_SUCCESS;
+	bool expects_reply = false;
+
+	if (MACH_MSGH_BITS_REMOTE(hdr->msgh_bits) == MACH_MSG_TYPE_MOVE_SEND_ONCE) {
+		expects_reply = true;
+	}
+
+	msg_reply->Head = (mach_msg_header_t){ };
+	if (unlikely(!demux(hdr, &msg_reply->Head))) {
+		rc = MIG_BAD_ID;
+	} else if (msg_reply->Head.msgh_bits & MACH_MSGH_BITS_COMPLEX) {
+		rc = KERN_SUCCESS;
+	} else {
+		// if MACH_MSGH_BITS_COMPLEX is _not_ set, then msg_reply->RetCode
+		// is present
+		rc = msg_reply->RetCode;
+	}
+
+	if (unlikely(rc == KERN_SUCCESS && expects_reply)) {
+		// if crashing here, some handler returned KERN_SUCCESS
+		// hoping for firehose_mig_server to perform the mach_msg()
+		// call to reply, and it doesn't know how to do that
+		DISPATCH_INTERNAL_CRASH(msg_reply->Head.msgh_id,
+				"firehose_mig_server doesn't handle replies");
+	}
+	if (unlikely(rc != KERN_SUCCESS && rc != MIG_NO_REPLY)) {
+		// destroy the request - but not the reply port
+		// (MIG moved it into the msg_reply).
+		hdr->msgh_remote_port = 0;
+		mach_msg_destroy(hdr);
+	}
+}
+
+#endif // !KERNEL
+#pragma mark -
+#pragma mark firehose buffer
+
+OS_ALWAYS_INLINE
+static inline firehose_chunk_t
+firehose_buffer_chunk_for_address(void *addr)
+{
+	uintptr_t chunk_addr = (uintptr_t)addr & ~(FIREHOSE_CHUNK_SIZE - 1);
+	return (firehose_chunk_t)chunk_addr;
+}
+
+OS_ALWAYS_INLINE
+static inline firehose_chunk_ref_t
+firehose_buffer_chunk_to_ref(firehose_buffer_t fb, firehose_chunk_t fbc)
+{
+	return (firehose_chunk_ref_t)(fbc - fb->fb_chunks);
+}
+
+OS_ALWAYS_INLINE
+static inline firehose_chunk_t
+firehose_buffer_ref_to_chunk(firehose_buffer_t fb, firehose_chunk_ref_t ref)
+{
+	return fb->fb_chunks + ref;
+}
+
+#ifndef FIREHOSE_SERVER
+#if DISPATCH_PURE_C
+
+#if OS_ATOMIC_HAS_STARVATION_FREE_RMW || !OS_ATOMIC_CONFIG_STARVATION_FREE_ONLY
+OS_ALWAYS_INLINE
+static inline void
+firehose_buffer_stream_flush(firehose_buffer_t fb, firehose_stream_t stream)
+{
+	firehose_buffer_stream_t fbs = &fb->fb_header.fbh_stream[stream];
+	firehose_stream_state_u old_state, new_state;
+	firehose_chunk_t fc;
+	uint64_t stamp = UINT64_MAX; // will cause the reservation to fail
+	firehose_chunk_ref_t ref;
+	long result;
+
+	old_state.fss_atomic_state =
+			os_atomic_load(&fbs->fbs_state.fss_atomic_state, relaxed);
+	ref = old_state.fss_current;
+	if (!ref || ref == FIREHOSE_STREAM_STATE_PRISTINE) {
+		// there is no installed page, nothing to flush, go away
+#ifndef KERNEL
+		firehose_buffer_force_connect(fb);
+#endif
+		return;
+	}
+
+	fc = firehose_buffer_ref_to_chunk(fb, old_state.fss_current);
+	result = firehose_chunk_tracepoint_try_reserve(fc, stamp, stream,
+			0, 1, 0, NULL);
+	if (likely(result < 0)) {
+		firehose_buffer_ring_enqueue(fb, old_state.fss_current);
+	}
+	if (unlikely(result > 0)) {
+		// because we pass a silly stamp that requires a flush
+		DISPATCH_INTERNAL_CRASH(result, "Allocation should always fail");
+	}
+
+	// as a best effort try to uninstall the page we just flushed
+	// but failing is okay, let's not contend stupidly for something
+	// allocators know how to handle in the first place
+	new_state = old_state;
+	new_state.fss_current = 0;
+	(void)os_atomic_cmpxchg(&fbs->fbs_state.fss_atomic_state,
+			old_state.fss_atomic_state, new_state.fss_atomic_state, relaxed);
+}
+
+/*!
+ * @function firehose_buffer_tracepoint_reserve
+ *
+ * @abstract
+ * Reserves space in the firehose buffer for the tracepoint with specified
+ * characteristics.
+ *
+ * @discussion
+ * This returns a slot, with the length of the tracepoint already set, so
+ * that in case of a crash, we maximize our chance to be able to skip the
+ * tracepoint in case of a partial write.
+ *
+ * Once the tracepoint has been written, firehose_buffer_tracepoint_flush()
+ * must be called.
+ *
+ * @param fb
+ * The buffer to allocate from.
+ *
+ * @param stream
+ * The buffer stream to use.
+ *
+ * @param pubsize
+ * The size of the public data for this tracepoint, cannot be 0, doesn't
+ * take the size of the tracepoint header into account.
+ *
+ * @param privsize
+ * The size of the private data for this tracepoint, can be 0.
+ *
+ * @param privptr
+ * The pointer to the private buffer, can be NULL
+ *
+ * @param reliable
+ * Whether we should wait for logd or drop the tracepoint in the event that no
+ * chunk is available.
+ *
+ * @result
+ * The pointer to the tracepoint.
+ */
+OS_ALWAYS_INLINE
+static inline firehose_tracepoint_t
+firehose_buffer_tracepoint_reserve(firehose_buffer_t fb, uint64_t stamp,
+		firehose_stream_t stream, uint16_t pubsize,
+		uint16_t privsize, uint8_t **privptr, bool reliable)
+{
+	firehose_buffer_stream_t fbs = &fb->fb_header.fbh_stream[stream];
+	firehose_stream_state_u old_state, new_state;
+	firehose_chunk_t fc;
+	bool waited = false;
+	bool success;
+	long result;
+	firehose_chunk_ref_t ref;
+
+	// cannot use os_atomic_rmw_loop, _page_try_reserve does a store
+	old_state.fss_atomic_state =
+			os_atomic_load(&fbs->fbs_state.fss_atomic_state, relaxed);
+	for (;;) {
+		new_state = old_state;
+
+		ref = old_state.fss_current;
+		if (likely(ref && ref != FIREHOSE_STREAM_STATE_PRISTINE)) {
+			fc = firehose_buffer_ref_to_chunk(fb, ref);
+			result = firehose_chunk_tracepoint_try_reserve(fc, stamp, stream,
+					0, pubsize, privsize, privptr);
+			if (likely(result > 0)) {
+				uint64_t thread;
+#if KERNEL
+				thread = thread_tid(current_thread());
+#else
+				thread = _pthread_threadid_self_np_direct();
+#endif
+				return firehose_chunk_tracepoint_begin(fc,
+						stamp, pubsize, thread, result);
+			}
+			if (likely(result < 0)) {
+				firehose_buffer_ring_enqueue(fb, old_state.fss_current);
+			}
+			new_state.fss_current = 0;
+		}
+
+		if (!reliable && ((waited && old_state.fss_timestamped)
+#ifndef KERNEL
+				|| old_state.fss_waiting_for_logd
+#endif
+			)) {
+			new_state.fss_loss =
+					MIN(old_state.fss_loss + 1, FIREHOSE_LOSS_COUNT_MAX);
+
+			success = os_atomic_cmpxchgv(&fbs->fbs_state.fss_atomic_state,
+					old_state.fss_atomic_state, new_state.fss_atomic_state,
+					&old_state.fss_atomic_state, relaxed);
+			if (success) {
+#ifndef KERNEL
+				_dispatch_trace_firehose_reserver_gave_up(stream, ref, waited,
+						old_state.fss_atomic_state, new_state.fss_atomic_state);
+#endif
+				return NULL;
+			} else {
+				continue;
+			}
+		}
+
+		if (unlikely(old_state.fss_allocator)) {
+#if KERNEL
+			_dispatch_firehose_gate_wait(&fbs->fbs_state.fss_gate,
+					DLOCK_LOCK_DATA_CONTENTION);
+			waited = true;
+
+			old_state.fss_atomic_state =
+					os_atomic_load(&fbs->fbs_state.fss_atomic_state, relaxed);
+#else
+			if (likely(reliable)) {
+				new_state.fss_allocator |= FIREHOSE_GATE_RELIABLE_WAITERS_BIT;
+			} else {
+				new_state.fss_allocator |= FIREHOSE_GATE_UNRELIABLE_WAITERS_BIT;
+			}
+
+			bool already_equal = (new_state.fss_atomic_state ==
+					old_state.fss_atomic_state);
+			success = already_equal || os_atomic_cmpxchgv(
+					&fbs->fbs_state.fss_atomic_state, old_state.fss_atomic_state,
+					new_state.fss_atomic_state, &old_state.fss_atomic_state,
+					relaxed);
+			if (success) {
+				_dispatch_trace_firehose_reserver_wait(stream, ref, waited,
+						old_state.fss_atomic_state, new_state.fss_atomic_state,
+						reliable);
+				_dispatch_firehose_gate_wait(&fbs->fbs_state.fss_gate,
+						new_state.fss_allocator,
+						DLOCK_LOCK_DATA_CONTENTION);
+				waited = true;
+
+				old_state.fss_atomic_state = os_atomic_load(
+						&fbs->fbs_state.fss_atomic_state, relaxed);
+			}
+#endif
+			continue;
+		}
+
+		// if the thread doing the allocation is of low priority we may starve
+		// threads of higher priority, so disable pre-emption before becoming
+		// the allocator (it is re-enabled in
+		// firehose_buffer_stream_chunk_install())
+		__firehose_critical_region_enter();
+#if KERNEL
+		new_state.fss_allocator = 1;
+#else
+		new_state.fss_allocator = _dispatch_lock_value_for_self();
+#endif
+		success = os_atomic_cmpxchgv(&fbs->fbs_state.fss_atomic_state,
+				old_state.fss_atomic_state, new_state.fss_atomic_state,
+				&old_state.fss_atomic_state, relaxed);
+		if (likely(success)) {
+			break;
+		}
+		__firehose_critical_region_leave();
+	}
+
+	struct firehose_tracepoint_query_s ask = {
+		.stamp = stamp,
+		.pubsize = pubsize,
+		.privsize = privsize,
+		.stream = stream,
+		.for_io = (firehose_stream_uses_io_bank & (1UL << stream)) != 0,
+#ifndef KERNEL
+		.quarantined = fb->fb_header.fbh_quarantined,
+#endif
+		.reliable = reliable,
+	};
+
+#ifndef KERNEL
+	_dispatch_trace_firehose_allocator(((uint64_t *)&ask)[0],
+			((uint64_t *)&ask)[1], old_state.fss_atomic_state,
+			new_state.fss_atomic_state);
+#endif
+
+	return firehose_buffer_tracepoint_reserve_slow(fb, &ask, privptr);
+}
+
+/*!
+ * @function firehose_buffer_tracepoint_flush
+ *
+ * @abstract
+ * Flushes a firehose tracepoint, and sends the chunk to the daemon when full
+ * and this was the last tracepoint writer for this chunk.
+ *
+ * @param fb
+ * The buffer the tracepoint belongs to.
+ *
+ * @param ft
+ * The tracepoint to flush.
+ *
+ * @param ftid
+ * The firehose tracepoint ID for that tracepoint.
+ * It is written last, preventing compiler reordering, so that its absence
+ * on crash recovery means the tracepoint is partial.
+ */
+OS_ALWAYS_INLINE
+static inline void
+firehose_buffer_tracepoint_flush(firehose_buffer_t fb,
+		firehose_tracepoint_t ft, firehose_tracepoint_id_u ftid)
+{
+	firehose_chunk_t fc = firehose_buffer_chunk_for_address(ft);
+
+	// Needed for process death handling (tracepoint-flush):
+	// We want to make sure the observers
+	// will see memory effects in program (asm) order.
+	// 1. write all the data to the tracepoint
+	// 2. write the tracepoint ID, so that seeing it means the tracepoint
+	//    is valid
+	if (firehose_chunk_tracepoint_end(fc, ft, ftid)) {
+		firehose_buffer_ring_enqueue(fb, firehose_buffer_chunk_to_ref(fb, fc));
+	}
+}
+
+OS_ALWAYS_INLINE
+static inline bool
+firehose_buffer_bank_try_reserve_slot(firehose_buffer_t fb, bool for_io,
+		firehose_bank_state_u *state_in_out)
+{
+	bool success;
+	firehose_buffer_bank_t fbb = &fb->fb_header.fbh_bank;
+
+	firehose_bank_state_u old_state = *state_in_out, new_state;
+	do {
+		if (unlikely(!old_state.fbs_banks[for_io])) {
+			return false;
+		}
+		new_state = old_state;
+		new_state.fbs_banks[for_io]--;
+
+		success = os_atomic_cmpxchgv(&fbb->fbb_state.fbs_atomic_state,
+				old_state.fbs_atomic_state, new_state.fbs_atomic_state,
+				&old_state.fbs_atomic_state, acquire);
+	} while (unlikely(!success));
+
+	*state_in_out = new_state;
+	return true;
+}
+#endif // OS_ATOMIC_HAS_STARVATION_FREE_RMW || !OS_ATOMIC_CONFIG_STARVATION_FREE_ONLY
+
+#ifndef KERNEL
+OS_ALWAYS_INLINE
+static inline void
+firehose_buffer_stream_signal_waiting_for_logd(firehose_buffer_t fb,
+		firehose_stream_t stream)
+{
+	firehose_stream_state_u state, new_state;
+	firehose_buffer_stream_t fbs = &fb->fb_header.fbh_stream[stream];
+
+	state.fss_atomic_state =
+			os_atomic_load(&fbs->fbs_state.fss_atomic_state, relaxed);
+	if (!state.fss_timestamped) {
+		fbs->fbs_loss_start = mach_continuous_time();
+
+		// release to publish the timestamp
+		os_atomic_rmw_loop(&fbs->fbs_state.fss_atomic_state,
+				state.fss_atomic_state, new_state.fss_atomic_state,
+				release, {
+			new_state = (firehose_stream_state_u){
+				.fss_allocator = (state.fss_allocator &
+						~FIREHOSE_GATE_UNRELIABLE_WAITERS_BIT),
+				.fss_current = state.fss_current,
+				.fss_loss = state.fss_loss,
+				.fss_timestamped = true,
+				.fss_waiting_for_logd = true,
+				.fss_generation = state.fss_generation,
+			};
+		});
+	} else {
+		os_atomic_rmw_loop(&fbs->fbs_state.fss_atomic_state,
+				state.fss_atomic_state, new_state.fss_atomic_state,
+				relaxed, {
+			new_state = (firehose_stream_state_u){
+				.fss_allocator = (state.fss_allocator &
+						~FIREHOSE_GATE_UNRELIABLE_WAITERS_BIT),
+				.fss_current = state.fss_current,
+				.fss_loss = state.fss_loss,
+				.fss_timestamped = true,
+				.fss_waiting_for_logd = true,
+				.fss_generation = state.fss_generation,
+			};
+		});
+	}
+
+	_dispatch_trace_firehose_wait_for_logd(stream, fbs->fbs_loss_start,
+			state.fss_atomic_state, new_state.fss_atomic_state);
+	if (unlikely(state.fss_allocator & FIREHOSE_GATE_UNRELIABLE_WAITERS_BIT)) {
+		_dispatch_gate_broadcast_slow(&fbs->fbs_state.fss_gate,
+				state.fss_gate.dgl_lock);
+	}
+}
+
+OS_ALWAYS_INLINE
+static inline void
+firehose_buffer_clear_bank_flags(firehose_buffer_t fb, unsigned long bits)
+{
+	firehose_buffer_bank_t fbb = &fb->fb_header.fbh_bank;
+	unsigned long orig_flags;
+
+	orig_flags = os_atomic_and_orig(&fbb->fbb_flags, ~bits, relaxed);
+	if (orig_flags != (orig_flags & ~bits)) {
+		firehose_buffer_update_limits(fb);
+	}
+}
+
+OS_ALWAYS_INLINE
+static inline void
+firehose_buffer_set_bank_flags(firehose_buffer_t fb, unsigned long bits)
+{
+	firehose_buffer_bank_t fbb = &fb->fb_header.fbh_bank;
+	unsigned long orig_flags;
+
+	orig_flags = os_atomic_or_orig(&fbb->fbb_flags, bits, relaxed);
+	if (orig_flags != (orig_flags | bits)) {
+		firehose_buffer_update_limits(fb);
+	}
+}
+
+OS_ALWAYS_INLINE
+static inline void
+firehose_buffer_bank_relinquish_slot(firehose_buffer_t fb, bool for_io)
+{
+	firehose_buffer_bank_t fbb = &fb->fb_header.fbh_bank;
+	os_atomic_add(&fbb->fbb_state.fbs_atomic_state, FIREHOSE_BANK_INC(for_io),
+			relaxed);
+}
+#endif // !KERNEL
+
+#endif // !defined(FIREHOSE_SERVER)
+
+#endif // DISPATCH_PURE_C
+
+#endif // __FIREHOSE_INLINE_INTERNAL__

--- a/src/Kernel/libfirehose_kernel/src/firehose_internal.h
+++ b/src/Kernel/libfirehose_kernel/src/firehose_internal.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2015 Apple Inc. All rights reserved.
+ *
+ * @APPLE_APACHE_LICENSE_HEADER_START@
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @APPLE_APACHE_LICENSE_HEADER_END@
+ */
+
+#ifndef __FIREHOSE_INTERNAL__
+#define __FIREHOSE_INTERNAL__
+
+#if OS_FIREHOSE_SPI
+
+// make sure this is defined so that we get MIG_SERVER_DIED when a send once
+// notification is sent back because of a crashed server
+#ifndef __MigTypeCheck
+#define __MigTypeCheck 1
+#endif
+
+#define fcp_quarntined fcp_quarantined
+
+#include <limits.h>
+#include <machine/endian.h>
+#include <mach/mach_types.h>
+#include <mach/std_types.h>
+#include <os/object.h>
+#include <firehose/private.h>
+#include <mach/mach_types.h>
+#include <mach/std_types.h>
+#include <sys/qos.h>
+
+#include "os/firehose_server_private.h"
+#include "firehose_buffer_internal.h"
+#ifdef FIREHOSE_SERVER
+#include "firehose_server_internal.h"
+#endif
+#include "firehose_inline_internal.h"
+
+#endif // OS_FIREHOSE_SPI
+
+#endif // __FIREHOSE_INTERNAL__

--- a/src/Libraries/libSystem/CMakeLists.txt
+++ b/src/Libraries/libSystem/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_subdirectory(corecrypto)
 add_subdirectory(libc)
-add_subdirectory(libdispatch)
+#add_subdirectory(libdispatch)
 add_subdirectory(libplatform)
 add_subdirectory(libmalloc)
 add_subdirectory(libsystem_kernel)

--- a/src/Libraries/libSystem/libdispatch/CMakeLists.txt
+++ b/src/Libraries/libSystem/libdispatch/CMakeLists.txt
@@ -1,1 +1,0 @@
-add_subdirectory(src/firehose)

--- a/tools/cctools/ld64/src/ld/parsers/CMakeLists.txt
+++ b/tools/cctools/ld64/src/ld/parsers/CMakeLists.txt
@@ -20,4 +20,4 @@ target_include_directories(host_ld_libparsers PRIVATE
 )
 target_link_libraries(host_ld_libparsers PRIVATE host_ld_helper)
 set_property(TARGET host_ld_libparsers PROPERTY CXX_STANDARD 11)
-suppress_warnings(host_ld_libparsers)
+suppress_all_warnings(host_ld_libparsers)

--- a/tools/cctools/ld64/src/ld/passes/CMakeLists.txt
+++ b/tools/cctools/ld64/src/ld/passes/CMakeLists.txt
@@ -29,4 +29,4 @@ target_include_directories(host_ld_libpasses PRIVATE
     ../../..
 )
 set_property(TARGET host_ld_libpasses PROPERTY CXX_STANDARD 11)
-suppress_warnings(host_ld_libpasses)
+suppress_all_warnings(host_ld_libpasses)

--- a/tools/cctools/misc/CMakeLists.txt
+++ b/tools/cctools/misc/CMakeLists.txt
@@ -29,10 +29,10 @@ cctools_misc_executable(cmpdylib)
 cctools_misc_executable(inout)
 cctools_misc_executable(vtool)
 
-suppress_warnings(host_bitcode_strip)
-suppress_warnings(host_install_name_tool)
-suppress_warnings(host_strip)
-suppress_warnings(host_vtool)
+suppress_all_warnings(host_bitcode_strip)
+suppress_all_warnings(host_install_name_tool)
+suppress_all_warnings(host_strip)
+suppress_all_warnings(host_vtool)
 
 # Special cases
 add_executable(host_nmedit strip.c)

--- a/tools/dtrace_ctf/tools/CMakeLists.txt
+++ b/tools/dtrace_ctf/tools/CMakeLists.txt
@@ -30,7 +30,7 @@ set_property(TARGET host_ctfconvert PROPERTY OUTPUT_NAME "ctfconvert")
 target_include_directories(host_ctfconvert PRIVATE ../include ../include/sys ../libelf)
 target_link_libraries(host_ctfconvert PRIVATE libelf.host libdwarf.host libctf.host ${ZLIB_LIBRARY_RELEASE})
 set_property(TARGET host_ctfconvert PROPERTY CXX_STANDARD 14)
-suppress_warnings(host_ctfconvert)
+suppress_all_warnings(host_ctfconvert)
 
 add_executable(host_ctfdump)
 target_sources(host_ctfdump PRIVATE
@@ -60,7 +60,7 @@ set_property(TARGET host_ctfdump PROPERTY OUTPUT_NAME "ctfdump")
 target_include_directories(host_ctfdump PRIVATE ../include ../include/sys ../libelf)
 target_link_libraries(host_ctfdump PRIVATE libelf.host libctf.host ${ZLIB_LIBRARY_RELEASE})
 set_property(TARGET host_ctfdump PROPERTY CXX_STANDARD 14)
-suppress_warnings(host_ctfdump)
+suppress_all_warnings(host_ctfdump)
 
 add_executable(host_ctfmerge)
 target_sources(host_ctfmerge PRIVATE
@@ -93,4 +93,4 @@ set_property(TARGET host_ctfmerge PROPERTY OUTPUT_NAME ctfmerge)
 target_include_directories(host_ctfmerge PRIVATE ../include ../include/sys ../libelf)
 target_link_libraries(host_ctfmerge PRIVATE libelf.host libdwarf.host libctf.host ${ZLIB_LIBRARY_RELEASE})
 set_property(TARGET host_ctfmerge PROPERTY CXX_STANDARD 14)
-suppress_warnings(host_ctfmerge)
+suppress_all_warnings(host_ctfmerge)

--- a/tools/xar/CMakeLists.txt
+++ b/tools/xar/CMakeLists.txt
@@ -31,7 +31,7 @@ set_property(TARGET host_libxar PROPERTY OUTPUT_NAME xar)
 target_include_directories(host_libxar PUBLIC include)
 target_include_directories(host_libxar PRIVATE ${OPENSSL_INCLUDE_DIR} ${LIBXML2_INCLUDE_DIR})
 target_link_libraries(host_libxar PRIVATE ZLIB::ZLIB LibXml2::LibXml2)
-suppress_warnings(host_libxar)
+suppress_all_warnings(host_libxar)
 
 add_executable(host_xar)
 target_sources(host_xar PRIVATE


### PR DESCRIPTION
* Rename `suppress_warnings()` CMake call to `suppress_all_warnings()`
* Move libfirehose_kernel out of libdispatch and into src/Kernel, where it belongs