### PR TITLE
March 10 Generic Cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,7 @@ cmake-build-*/
 
 ## Visual Studio Code
 .vscode/
+.cache/
 
 ## Other
 *.moved-aside

--- a/cmake/crosscompile.cmake
+++ b/cmake/crosscompile.cmake
@@ -36,11 +36,6 @@ function(add_darwin_static_library name)
     add_dependencies(${name} host_libtool)
     target_compile_definitions(${name} PRIVATE __PUREDARWIN__)
 
-    string(SUBSTRING ${name} 0 3 name_prefix)
-    if(name_prefix STREQUAL "lib")
-        set_property(TARGET ${name} PROPERTY PREFIX "")
-    endif()
-
     if(SL_MACOSX_VERSION_MIN)
         target_compile_options(${name} PRIVATE -target x86_64-apple-macos${SL_MACOSX_VERSION_MIN})
     elseif(CMAKE_MACOSX_MIN_VERSION)

--- a/src/Kernel/libfirehose_kernel/CMakeLists.txt
+++ b/src/Kernel/libfirehose_kernel/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_darwin_static_library(libfirehose_kernel)
+set_property(TARGET libfirehose_kernel PROPERTY OUTPUT_NAME "firehose_kernel")
 target_sources(libfirehose_kernel PRIVATE
     src/firehose_buffer.c
 )

--- a/src/Kernel/libkmod/CMakeLists.txt
+++ b/src/Kernel/libkmod/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_darwin_static_library(libkmod)
+set_property(TARGET libkmod PROPERTY OUTPUT_NAME "kmod")
 target_sources(libkmod PRIVATE c_start.c c_stop.c)
 target_link_libraries(libkmod PRIVATE xnu_kernel_headers AvailabilityHeaders)
 target_compile_definitions(libkmod PRIVATE TARGET_OS_OSX)

--- a/src/Libraries/libSystem/libdispatch/src/firehose/CMakeLists.txt
+++ b/src/Libraries/libSystem/libdispatch/src/firehose/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_darwin_static_library(libfirehose_kernel)
+set_property(TARGET libfirehose_kernel PROPERTY OUTPUT_NAME firehose_kernel)
 target_sources(libfirehose_kernel PRIVATE
     src/firehose_buffer.c
 )

--- a/src/Libraries/libSystem/libsystem_kernel/CMakeLists.txt
+++ b/src/Libraries/libSystem/libsystem_kernel/CMakeLists.txt
@@ -58,7 +58,7 @@ target_include_directories(libsystem_kernel_private_headers INTERFACE private_in
 add_darwin_static_library(libsystem_kernel_static)
 
 # This product should be called libsystem_kernel.a and should be placed in /usr/local/lib/{dyld,system,loaderd,dyld_stub}
-set_target_properties(libsystem_kernel_static PROPERTIES OUTPUT_NAME "libsystem_kernel")
+set_target_properties(libsystem_kernel_static PROPERTIES OUTPUT_NAME "system_kernel")
 
 target_sources(libsystem_kernel_static PRIVATE
     ${CMAKE_CURRENT_BINARY_DIR}/syscalls.a


### PR DESCRIPTION
This PR does the following:

1. Adds `.cache` to the gitignore. This directory is emitted by Codium but not by VSCode.
2. Remove the code from `add_darwin_static_library()` that automatically sets the `PREFIX` of targets that start with `lib`. This is not the correct way to do this.
3. Fix a few misnamed libraries after the second change.