### PR TITLE
June 11 Minor Generic Cleanup

### DIFF
--- a/src/Kernel/Extensions/IOPCIFamily/ApplePIODMA/CMakeLists.txt
+++ b/src/Kernel/Extensions/IOPCIFamily/ApplePIODMA/CMakeLists.txt
@@ -8,4 +8,4 @@ target_sources(ApplePIODMA PRIVATE
 
 set_property(TARGET ApplePIODMA PROPERTY CXX_STANDARD 11)
 target_link_libraries(ApplePIODMA PRIVATE IOPCIFamilyHeaders)
-install(TARGETS ApplePIODMA DESTINATION /System/Library/Extensions COMPONENT BaseSystem)
+install(TARGETS ApplePIODMA DESTINATION System/Library/Extensions COMPONENT BaseSystem)

--- a/src/Kernel/Extensions/IOStorageFamily/CMakeLists.txt
+++ b/src/Kernel/Extensions/IOStorageFamily/CMakeLists.txt
@@ -61,5 +61,5 @@ foreach(file IN LISTS HEADERS)
     target_sources(IOStorageFamilyUserHeaders PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/user_include/IOKit/storage/${file})
 endforeach()
 
-install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/user_include/IOKit/storage DESTINATION /System/Library/Frameworks/IOKit.framework/Versions/A/Headers/IOKit COMPONENT DeveloperTools)
-install(DIRECTORY include/IOKit/storage DESTINATION /System/Library/Frameworks/Kernel.framework/Versions/A/Headers/IOKit COMPONENT DeveloperTools)
+install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/user_include/IOKit/storage DESTINATION System/Library/Frameworks/IOKit.framework/Versions/A/Headers/IOKit COMPONENT DeveloperTools)
+install(DIRECTORY include/IOKit/storage DESTINATION System/Library/Frameworks/Kernel.framework/Versions/A/Headers/IOKit COMPONENT DeveloperTools)

--- a/src/Kernel/xnu/CMakeLists.txt
+++ b/src/Kernel/xnu/CMakeLists.txt
@@ -100,7 +100,11 @@ externalproject_add(xnu
     USES_TERMINAL_CONFIGURE TRUE
     USES_TERMINAL_BUILD TRUE
 )
-add_dependencies(xnu xnu_headers libfirehose_kernel host_codesign_allocate host_ctfconvert host_ctfmerge migcom host_strip host_lipo host_nm unifdef host_nmedit availability.pl host_ld)
+add_dependencies(xnu
+    xnu_headers libfirehose_kernel host_codesign_allocate host_ctfconvert host_ctfmerge
+    migcom host_strip host_lipo host_nm unifdef host_nmedit availability.pl host_ld
+    dyld_availability_headers
+)
 
 install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/xnu/System/Library/Frameworks/Kernel.framework/Versions/A/Resources DESTINATION System/Library/Frameworks/Kernel.framework/Versions/A COMPONENT BaseSystem)
 install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/xnu/System/Library/Frameworks/Kernel.framework/Versions/A/Headers DESTINATION System/Library/Frameworks/Kernel.framework/Versions/A COMPONENT DeveloperTools)


### PR DESCRIPTION
This PR does the following:

* Fixes a severe error in a CMake `install` statement. Were it not for System Integrity Protection, installing PureDarwin using sudo without this patch would overwrite the Apple copy of these files, rendering the system unbootable.
* Adds `dyld_availability_headers` dependency to `xnu`. Without this, installation would complain this target hasn’t been built.
