### PR TITLE
Readme: Fix logo on light mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # PureDarwin   [![PureDarwin Discord](https://dcbadge.limes.pink/api/server/https://discord.gg/9kz8XXRRcT?style=flat)](https://discord.gg/9kz8XXRRcT)
 
-![](https://www.puredarwin.org/images/logo-mark-text-fff.svg)
-
+![logo-sm](https://github.com/user-attachments/assets/ea4bd560-3738-4486-80ab-2f313e4a33a1)
 
 Darwin is the Open Source operating system from Apple that forms the basis for Mac OS X and PureDarwin. PureDarwin is a community project that aims to make Darwin more usable (some people think of it as the informal successor to OpenDarwin).
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Darwin is the Open Source operating system from Apple that forms the basis for M
 
 One current goal of this project is to provide a useful bootable ISO/VM of some recent version of Darwin.
 
-See the [Website](https://puredarwin.org) for more information.
+See the [Website](https://www.puredarwin.org) for more information.
 
 ## Building PureDarwin
 


### PR DESCRIPTION
should have thought about this before my last PR, but the logo only showed up on GitHub in dark mode.