### PR TITLE
Remove forced CMAKE_INSTALL_PREFIX.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,6 @@ endif()
 
 cmake_policy(SET CMP0114 NEW)
 
-set(CMAKE_INSTALL_PREFIX "")
 set(CMAKE_MACOSX_MIN_VERSION 11.0)
 
 include(ExternalProject)


### PR DESCRIPTION
The CMakeLists.txt currently forces the install prefix to be the root of the OS, this patch simply removes this, allowing you to build and "install" PureDarwin into a folder of your choosing. This makes iterative building far easier.