### PR TITLE
DenseMapInfo.h: Include `<cstring>` for `strlen`/`strcmp`

### DIFF
--- a/tools/dtrace_ctf/include/llvm-ADT/DenseMapInfo.h
+++ b/tools/dtrace_ctf/include/llvm-ADT/DenseMapInfo.h
@@ -14,6 +14,7 @@
 #define LLVM_ADT_DENSEMAPINFO_H
 
 #include <memory>
+#include <cstring>
 
 namespace llvm {
 


### PR DESCRIPTION
- See https://github.com/PureDarwin/PureDarwin/issues/164