### PR TITLE
Update to Node24

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,9 @@
+version: 2
+
+# Update CI once a month, or at least have a PR for it.
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 1

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -10,7 +10,7 @@ jobs:
 
     steps:
       - name: Clone
-        uses: actions/checkout@v2
+        uses: actions/checkout@v7
       - name: Install Packages
         run: |
           export HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1


### PR DESCRIPTION
# Problem

The job action is very behind and could use some love.

# Solution

Update to the latest version of `actions/checkout@v7`

# QA

As long as CI passes this should be safe to merge.